### PR TITLE
Fix `pack_to_file` on Windows

### DIFF
--- a/src/flashpack/serialization.py
+++ b/src/flashpack/serialization.py
@@ -214,6 +214,12 @@ def pack_to_file(
                 except OSError:
                     pass
 
+        # Explicitly close memory map
+        # `_mmap` in numpy <= 1.25, `base` in numpy >= 1.26
+        mm_base = getattr(mm, "_mmap", None) or getattr(mm, "base", None)
+        if mm_base is not None:
+            mm_base.close()
+
         # Atomic replace
         with timer("atomic_rename", silent):
             os.replace(tmp_path, destination_path)


### PR DESCRIPTION
On Windows the `numpy` memory map needs to be explicitly closed.

```
217 # Atomic replace 218 with timer("atomic_rename", silent): --> 
219 os.replace(tmp_path, destination_path)
220 tmp_path = None
222 finally:
223 # Cleanup on error 
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'H:\\flashpack_vae\\.packtmp_x862pael' -> 'H:/flashpack_vae\\model.flashpack'
```

```
from flashpack.integrations.diffusers import patch_diffusers_auto_model

patch_diffusers_auto_model()

from diffusers.models import AutoModel

model = AutoModel.from_pretrained(
    "stable-diffusion-v1-5/stable-diffusion-v1-5",
    subfolder="vae",
)

model.save_pretrained_flashpack("H:/flashpack_vae")
```

As mentioned in the code comment the attribute varies with `numpy` version - `_mmap` in `numpy <= 1.25`, `base` in `numpy >= 1.26`

cc @painebenjamin 