### PR TITLE
fix: eval mode, materialize non-persistent buffers, guard fp8 dtypes in loader

### DIFF
--- a/src/flashpack/mixin.py
+++ b/src/flashpack/mixin.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import inspect
+import itertools
+import warnings
 from collections.abc import Callable
 from typing import Any, ClassVar
 
@@ -59,7 +61,17 @@ class FlashPackMixin:
             else device
         )
 
-        with init_empty_weights():
+        # ``include_buffers=False`` keeps parameters on the meta device (the
+        # memory win) while letting the module's ``__init__`` materialize its
+        # buffers with their real, computed values. Packs only contain
+        # ``state_dict()`` (i.e. persistent buffers), so non-persistent buffers
+        # such as CLIP ``position_ids`` or rotary ``inv_freq`` are never written
+        # to the pack; if they were placed on the meta device here they would
+        # stay meta after loading and later crash ("Cannot copy out of meta
+        # tensor") or silently corrupt outputs. Passing this explicitly also
+        # overrides the ``ACCELERATE_INIT_INCLUDE_BUFFERS`` environment variable,
+        # which otherwise flips accelerate's default to put buffers on meta.
+        with init_empty_weights(include_buffers=False):
             if init_fn is None:
                 if cls.flashpack_init_method is not None and hasattr(
                     cls, cls.flashpack_init_method
@@ -99,6 +111,37 @@ class FlashPackMixin:
             world_size=world_size,
             coerce_dtype=coerce_dtype or cls.flashpack_coerce_dtype,
         )
+
+        if isinstance(model, torch.nn.Module):
+            # Match diffusers' ``ModelMixin.from_pretrained`` and transformers'
+            # ``PreTrainedModel.from_pretrained``, which both return the model in
+            # evaluation mode. Without this, dropout/other train-only layers
+            # stay active (e.g. T5's dropout ``p=0.1``), producing
+            # nondeterministic, corrupted inference outputs. Callers that want
+            # to fine-tune can re-enable training with ``model.train()``.
+            model.eval()
+
+            # ``init_empty_weights`` allocates parameters on the meta device.
+            # Anything left unmaterialized after loading (a tensor missing from
+            # the pack while a non-strict flag is set) stays on meta and will
+            # crash or silently corrupt outputs when used. Surface it loudly
+            # rather than failing deep inside a forward pass later.
+            leftover_meta = [
+                name
+                for name, tensor in itertools.chain(
+                    model.named_parameters(), model.named_buffers()
+                )
+                if tensor.is_meta
+            ]
+            if leftover_meta:
+                warnings.warn(
+                    f"flashpack: {len(leftover_meta)} tensor(s) remain on the "
+                    f"meta device after loading from {path!r} and were not "
+                    f"materialized: {leftover_meta}. Using the model will crash "
+                    "or produce incorrect results.",
+                    stacklevel=2,
+                )
+
         return model
 
     def save_flashpack(

--- a/src/flashpack/utils.py
+++ b/src/flashpack/utils.py
@@ -16,6 +16,25 @@ try:
 except AttributeError:
     float4_e2m1fn = None  # type: ignore
 
+# fp8 dtypes were introduced across several torch releases (e.g.
+# ``float8_e8m0fnu`` only exists on torch >= 2.7). Resolve them by name so the
+# packing helpers keep importing and running on older torch builds, matching the
+# ``torch>=2.0`` support claimed in the project metadata. Referencing the
+# attributes unconditionally raises ``AttributeError`` on every call on torch
+# builds that lack them (e.g. torch 2.6).
+_FP8_DTYPE_NAMES = (
+    "float8_e4m3fn",
+    "float8_e4m3fnuz",
+    "float8_e5m2",
+    "float8_e5m2fnuz",
+    "float8_e8m0fnu",
+)
+_FP8_DTYPES: tuple[torch.dtype, ...] = tuple(
+    d
+    for d in (getattr(torch, name, None) for name in _FP8_DTYPE_NAMES)
+    if d is not None
+)
+
 
 def maybe_init_distributed(
     rank: int | None = None,
@@ -81,13 +100,7 @@ def get_packing_dtype(dtype: torch.dtype) -> torch.dtype:
     """
     if dtype is float4_e2m1fn:
         raise ValueError(f"Unsupported dtype for packing: {dtype}")
-    elif dtype in [
-        torch.float8_e4m3fn,
-        torch.float8_e4m3fnuz,
-        torch.float8_e5m2,
-        torch.float8_e5m2fnuz,
-        torch.float8_e8m0fnu,
-    ]:
+    elif dtype in _FP8_DTYPES:
         return torch.uint8
     elif dtype is torch.bfloat16:
         return torch.uint16
@@ -125,14 +138,13 @@ def torch_dtype_to_numpy_dtype(dtype: torch.dtype) -> np.dtype:
         torch.complex64: np.complex64,
         torch.complex128: np.complex128,
         # unsupported dtypes, we map to uints
-        torch.float8_e4m3fn: np.uint8,
-        torch.float8_e4m3fnuz: np.uint8,
-        torch.float8_e5m2: np.uint8,
-        torch.float8_e5m2fnuz: np.uint8,
-        torch.float8_e8m0fnu: np.uint8,
         torch.bfloat16: np.uint16,
         torch.complex32: np.uint32,
     }
+    # fp8 dtypes have no numpy analogue; store their raw bytes as uint8. Only the
+    # ones present in this torch build are registered (see ``_FP8_DTYPES``).
+    for fp8_dtype in _FP8_DTYPES:
+        mapping[fp8_dtype] = np.uint8
     if dtype not in mapping:
         raise ValueError(f"Unsupported dtype for packing: {dtype}")
     return mapping[dtype]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,146 @@
+"""Regression tests for flashpack loading correctness.
+
+Each test targets a bug found while loading a diffusers/transformers stack via
+flashpack (see fal-ai/registry#11335):
+
+* ``from_flashpack`` returning models in training mode (dropout active).
+* the dtype helpers raising ``AttributeError`` on torch builds without the newer
+  fp8 dtypes.
+* non-persistent buffers being left on the meta device.
+"""
+
+import importlib
+
+import numpy as np
+import pytest
+import torch
+from flashpack import FlashPackMixin
+
+
+class ModelWithDropout(torch.nn.Module, FlashPackMixin):
+    def __init__(self, features: int = 8) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(features, features)
+        self.dropout = torch.nn.Dropout(p=0.5)
+
+
+class ModelWithBuffers(torch.nn.Module, FlashPackMixin):
+    """Mirrors the CLIP/rotary pattern: a persistent buffer that lands in the
+    pack and a non-persistent buffer that does not."""
+
+    def __init__(self, features: int = 8) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(features, features)
+        # Persistent buffer: written to the pack via ``state_dict()``.
+        self.register_buffer("scale", torch.full((features,), 3.0))
+        # Non-persistent buffer: absent from ``state_dict()``, like CLIP
+        # ``position_ids`` or rotary ``inv_freq``. Must be materialized by
+        # ``__init__`` rather than restored from the pack.
+        self.register_buffer(
+            "position_ids",
+            torch.arange(features, dtype=torch.long),
+            persistent=False,
+        )
+
+
+def _save(model: torch.nn.Module, tmp_path) -> str:
+    path = str(tmp_path / "model.flashpack")
+    model.save_flashpack(path, target_dtype=torch.float32)
+    return path
+
+
+def test_from_flashpack_returns_eval_mode(tmp_path) -> None:
+    """Bug 1: loaded models must be in eval mode, matching diffusers/transformers
+    ``from_pretrained`` (dropout deactivated)."""
+    source = ModelWithDropout()
+    source.train()  # ensure the source is in train mode before packing
+    path = _save(source, tmp_path)
+
+    loaded = ModelWithDropout.from_flashpack(path, features=8)
+
+    assert loaded.training is False
+    # ``eval()`` must propagate to submodules so dropout is deactivated.
+    assert loaded.dropout.training is False
+
+
+def test_dtype_helpers_without_float8_e8m0fnu(monkeypatch) -> None:
+    """Bug 2: the packing dtype helpers must import and run on torch builds that
+    predate ``torch.float8_e8m0fnu`` (added in torch 2.7)."""
+    import flashpack.utils as utils
+
+    # Simulate an older torch build (e.g. torch 2.6) lacking the newest fp8 dtype.
+    monkeypatch.delattr(torch, "float8_e8m0fnu", raising=False)
+    try:
+        importlib.reload(utils)
+
+        assert not hasattr(torch, "float8_e8m0fnu")
+        # The resolved set drops the missing dtype but keeps the present ones...
+        assert torch.float8_e4m3fn in utils._FP8_DTYPES
+        # ... and both helpers run without raising AttributeError.
+        assert utils.get_packing_dtype(torch.float8_e4m3fn) is torch.uint8
+        assert utils.torch_dtype_to_numpy_dtype(torch.float8_e4m3fn) is np.uint8
+        # Unrelated dtypes are unaffected.
+        assert utils.get_packing_dtype(torch.bfloat16) is torch.uint16
+        assert utils.torch_dtype_to_numpy_dtype(torch.float32) is np.float32
+    finally:
+        monkeypatch.undo()
+        importlib.reload(utils)
+
+
+@pytest.mark.parametrize("include_buffers_env", [None, "true"])
+def test_nonpersistent_buffer_is_materialized(
+    tmp_path, monkeypatch, include_buffers_env
+) -> None:
+    """Bug 3: a non-persistent buffer must round-trip materialized (not meta) with
+    its ``__init__`` value.
+
+    With ``ACCELERATE_INIT_INCLUDE_BUFFERS=true`` (the condition that reproduced
+    the fal-ai/registry#11335 failure) the unfixed loader leaves the buffer on the
+    meta device; the explicit ``include_buffers=False`` in ``from_flashpack``
+    overrides the env var and keeps it materialized.
+    """
+    if include_buffers_env is None:
+        monkeypatch.delenv("ACCELERATE_INIT_INCLUDE_BUFFERS", raising=False)
+    else:
+        monkeypatch.setenv("ACCELERATE_INIT_INCLUDE_BUFFERS", include_buffers_env)
+
+    source = ModelWithBuffers()
+    expected_position_ids = source.position_ids.clone()
+    path = _save(source, tmp_path)
+
+    loaded = ModelWithBuffers.from_flashpack(path, features=8)
+
+    # Non-persistent buffer: materialized by __init__, never on meta.
+    assert loaded.position_ids.is_meta is False
+    assert torch.equal(loaded.position_ids, expected_position_ids)
+    # Persistent buffer: restored from the pack.
+    assert loaded.scale.is_meta is False
+    assert torch.equal(loaded.scale, source.scale)
+    # Parameters: restored from the pack.
+    assert loaded.linear.weight.is_meta is False
+    assert torch.equal(loaded.linear.weight, source.linear.weight)
+
+
+def test_leftover_meta_tensor_warns(tmp_path) -> None:
+    """Bug 3 (defensive): a parameter missing from the pack under a non-strict
+    flag stays on meta; the loader must warn loudly instead of silently returning
+    a broken model."""
+
+    class SmallModel(torch.nn.Module, FlashPackMixin):
+        def __init__(self, features: int = 8) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(features, features)
+
+    class BiggerModel(torch.nn.Module, FlashPackMixin):
+        def __init__(self, features: int = 8) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(features, features)
+            # Extra parameter with no counterpart in the pack.
+            self.extra = torch.nn.Parameter(torch.zeros(features))
+
+    path = _save(SmallModel(), tmp_path)
+
+    with pytest.warns(UserWarning, match="meta device"):
+        loaded = BiggerModel.from_flashpack(path, features=8, strict_params=False)
+
+    assert loaded.extra.is_meta is True


### PR DESCRIPTION
## Summary

Fixes three correctness bugs in the flashpack loader, all surfaced while loading a diffusers/transformers stack via flashpack in fal's flux-general serving app (fal-ai/registry#11335). Each bug is covered by a regression test in `tests/test_regression.py`, and the first three were verified to fail on the unpatched loader.

## Bug 1 — models returned in training mode (dropout active)

`FlashPackMixin.from_flashpack` builds the module under `accelerate.init_empty_weights()` and returns it without ever calling `model.eval()`. This diverges from the loaders flashpack is meant to be a drop-in replacement for:

- diffusers `ModelMixin.from_pretrained` calls `model.eval()` before returning.
- transformers `PreTrainedModel.from_pretrained` calls `model.eval()` before returning.
- flashpack's own docstring at `src/flashpack/integrations/diffusers/auto_model.py:46-47` already **claims** "The model is set in evaluation mode - `model.eval()` - by default, and dropout modules are deactivated." — a contract the code did not honor.

**Real-world impact:** the T5-XXL text encoder loaded via flashpack in fal-ai/registry#11335 (flux-general) ran with dropout (`p=0.1`) **active on every request**. Because `nn.Module` defaults to `training=True`, inference was nondeterministic even with fixed seeds — image-similarity scores drifted to 0.3–0.56 against a 0.6 golden-gate threshold, with failures varying run to run.

**Fix:** call `model.eval()` at the end of `from_flashpack`. This covers the diffusers/transformers model mixins and the pipeline loader too, since `from_pretrained_flashpack` on both mixins (and each flashpack component loaded inside `FlashPackDiffusionPipeline.from_pretrained_flashpack` via `load_sub_model_flashpack`) routes through `from_flashpack`; non-flashpack pipeline components are loaded by their own `from_pretrained`, which already eval.

## Bug 2 — `torch.float8_e8m0fnu` referenced unguarded

`get_packing_dtype` and `torch_dtype_to_numpy_dtype` in `src/flashpack/utils.py` reference `torch.float8_e8m0fnu`, which only exists on **torch >= 2.7**. On torch 2.6 both functions raise `AttributeError` on *every* call (the attribute is touched while building an inline `list`/`dict` literal), which forced downstream apps to install a shim. This breaks the `torch>=2.0` support the project metadata advertises.

**Fix:** resolve the fp8 dtypes by name once via `getattr(torch, name, None)`, keeping only those present on the running torch build, and reference that set in both helpers (mirrors the existing `float4_e2m1fn` guard).

## Bug 3 — non-persistent buffers left on the meta device

Packs store only `state_dict()`, which by definition excludes **non-persistent** buffers (registered with `persistent=False`) — e.g. CLIP `position_ids`, rotary `inv_freq`. When `accelerate` places buffers on the meta device during `init_empty_weights()`, those buffers are never written to the pack and so remain **meta tensors** after `assign_from_file` (`strict_buffers=False` hides it). Downstream this crashes with `Cannot copy out of meta tensor`, or — worse — silently corrupts results when a meta tensor is used as an embedding index.

I verified accelerate's behavior empirically on the pinned stack (accelerate 1.14.0, torch 2.13.0):

| `init_empty_weights(...)` | `ACCELERATE_INIT_INCLUDE_BUFFERS` | non-persistent buffer after init |
|---|---|---|
| `()` default | unset | materialized (fine) |
| `()` default | `true` | **on meta (bug)** |
| `(include_buffers=True)` | any | **on meta (bug)** |
| `(include_buffers=False)` | any | materialized (fixed) |

So the meta-buffer failure is triggered whenever `include_buffers` resolves to `True` — most commonly because the `ACCELERATE_INIT_INCLUDE_BUFFERS` environment variable is set in the runner, which flips accelerate's default. flashpack silently inherited that.

**Fix (and tradeoff):** pass `include_buffers=False` explicitly to `init_empty_weights` in `from_flashpack`. This deterministically overrides the env var / accelerate default: parameters still go to meta (the memory win is preserved — confirmed: `lin.weight.is_meta` stays `True` in all cases above), while the module's `__init__` materializes buffers with their real computed values. Buffers are small, so materializing them in `__init__` is cheap; the only theoretical downside is a model that computes a very large buffer in `__init__`, which is rare and still correct. As defense-in-depth I also added a loud `warnings.warn` after loading that lists any parameter/buffer still on the meta device (e.g. a parameter missing from the pack under a non-strict flag), so future gaps fail loudly instead of silently.

## Tests

`tests/test_regression.py`:

- `test_from_flashpack_returns_eval_mode` — loaded model (and its dropout submodule) has `training is False`.
- `test_dtype_helpers_without_float8_e8m0fnu` — with `torch.float8_e8m0fnu` monkeypatch-deleted and `flashpack.utils` reloaded, both dtype helpers import and run without `AttributeError`.
- `test_nonpersistent_buffer_is_materialized[None|true]` — a non-persistent buffer round-trips materialized (not meta) with its `__init__` value, including under `ACCELERATE_INIT_INCLUDE_BUFFERS=true`; persistent buffers and parameters still restore from the pack.
- `test_leftover_meta_tensor_warns` — loading a model whose extra parameter is absent from the pack (with `strict_params=False`) warns about the leftover meta tensor.

Verified locally on CPU (torch 2.13.0, accelerate 1.14.0, numpy 2.4.6): `tests/test_regression.py` and the existing serialization/deserialization suite `tests/test_baseline.py` — **9 passed**. Stashing the source fixes and re-running the regression tests reproduces the bugs (4 fail; the default-env buffer variant passes on both, as expected since accelerate 1.14's default already materializes buffers). `ruff check`, ruff import sort, and `ruff format --check` all clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
