### PR TITLE
v0.3.1: harden the parallel read path (stream ordering + error drain), tests, fleet benchmark harness

### DIFF
--- a/scripts/bench_load_parallel.py
+++ b/scripts/bench_load_parallel.py
@@ -27,7 +27,6 @@ import sys
 import time
 
 import torch
-
 from flashpack.deserialization import read_flashpack_file
 from flashpack.serialization import pack_to_file
 

--- a/scripts/bench_load_parallel.py
+++ b/scripts/bench_load_parallel.py
@@ -1,0 +1,172 @@
+"""Benchmark + validate the CUDA load paths: legacy mmap walk vs parallel
+O_DIRECT reader (FLASHPACK_PARALLEL_READ).
+
+Run on a GPU host. Builds (or reuses) a synthetic multi-dtype pack, then for
+each variant: loads it to CUDA, reports seconds + GB/s, and bit-verifies the
+loaded macroblocks against a CPU mmap reference (every variant is verified
+unless --no-verify).
+
+Usage:
+    python scripts/bench_load_parallel.py --size-gb 8 --dir /tmp
+    python scripts/bench_load_parallel.py --size-gb 24 --dir /data/bench --cold
+    python scripts/bench_load_parallel.py --pack /data/some/model.flashpack
+
+Cold runs (--cold): every measurement gets its own fresh copy of the pack
+(JuiceFS/network mounts cache per FILE, so a fresh copy is cold for the
+mount too), and the copy's pages are evicted from the page cache (fsync +
+POSIX_FADV_DONTNEED) right before the measurement. Rows are labeled
+cold/warm so mixed tables can't be misread. Caveat: copies written by THIS
+host may remain in the mount's local write cache — for strictly cold
+network-FS numbers, seed the copies from a different host.
+"""
+
+import argparse
+import os
+import shutil
+import sys
+import time
+
+import torch
+
+from flashpack.deserialization import read_flashpack_file
+from flashpack.serialization import pack_to_file
+
+GB = 1024**3
+VARIANTS = {
+    "legacy": {"FLASHPACK_PARALLEL_READ": "0"},
+    "parallel": {"FLASHPACK_PARALLEL_READ": "1"},
+    "parallel-buffered": {"FLASHPACK_PARALLEL_READ": "1", "FLASHPACK_DIRECT_IO": "0"},
+}
+
+
+def build_pack(path: str, size_gb: float) -> None:
+    """Synthetic pack shaped like a real DiT artifact: dominant bf16 block plus
+    small fp32/int64/bool blocks (multiple macroblocks, V4 layout)."""
+    torch.manual_seed(0)
+    bf16_bytes = int(size_gb * GB * 0.97)
+    per = (bf16_bytes // 2) // 16
+    sd: dict[str, torch.Tensor] = {
+        f"blocks.{i}.w": torch.randn(per, dtype=torch.bfloat16) for i in range(16)
+    }
+    sd["norm.weight"] = torch.randn(4096, dtype=torch.float32)
+    sd["ids"] = torch.randint(0, 1 << 30, (1 << 20,), dtype=torch.int64)
+    sd["mask"] = torch.randint(0, 2, (1 << 20,), dtype=torch.int64).bool()
+    print(f"packing {size_gb:.1f} GB synthetic checkpoint -> {path}", flush=True)
+    pack_to_file(sd, path, target_dtype=None)
+
+
+def evict_page_cache(path: str) -> bool:
+    """Drop the file's pages from the OS page cache (a freshly written copy is
+    fully resident, so without this a "cold" measurement is actually warm)."""
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(fd)
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+        return True
+    except OSError:
+        return False
+    finally:
+        os.close(fd)
+
+
+def verify(path: str, storage) -> None:
+    """Bit-verify every CUDA macroblock against the CPU mmap reference."""
+    ref, _ = read_flashpack_file(path, device="cpu")
+    assert len(ref.blocks) == len(storage.blocks)
+    for i, (cpu_b, gpu_b) in enumerate(zip(ref.blocks, storage.blocks)):
+        a = cpu_b.view(torch.uint8) if cpu_b.dtype.is_floating_point else cpu_b
+        b = gpu_b.cpu()
+        b = b.view(torch.uint8) if b.dtype.is_floating_point else b
+        if not torch.equal(a, b):
+            raise AssertionError(f"macroblock {i} differs from reference")
+    print("    verify: all macroblocks bit-exact vs CPU reference", flush=True)
+
+
+def bench_one(path: str, variant: str, cold: bool, do_verify: bool) -> float:
+    size = os.path.getsize(path)
+    old_env = {k: os.environ.get(k) for k in VARIANTS[variant]}
+    os.environ.update(VARIANTS[variant])
+    try:
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        storage, _meta = read_flashpack_file(path, device="cuda")
+        torch.cuda.synchronize()
+        dt = time.perf_counter() - t0
+    finally:
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    rate = size / dt / GB
+    print(
+        f"{variant:<18s} [{'cold' if cold else 'warm'}]: {dt:7.2f}s  {rate:6.2f} GB/s",
+        flush=True,
+    )
+    if do_verify:
+        # verification re-reads on CPU (warms the cache) — it runs AFTER the
+        # timed load, and cold mode gives every row its own copy
+        verify(path, storage)
+    del storage
+    torch.cuda.empty_cache()
+    return rate
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--pack", help="existing .flashpack to load (skips synthesis)")
+    ap.add_argument("--size-gb", type=float, default=8.0)
+    ap.add_argument("--dir", default="/tmp", help="where to build the synthetic pack")
+    ap.add_argument(
+        "--variants", nargs="+", default=list(VARIANTS), choices=list(VARIANTS)
+    )
+    ap.add_argument(
+        "--cold",
+        action="store_true",
+        help="one fresh, page-cache-evicted copy per measurement",
+    )
+    ap.add_argument("--no-verify", action="store_true")
+    args = ap.parse_args()
+
+    assert torch.cuda.is_available(), "CUDA required (run on a GPU host)"
+
+    if args.pack:
+        base = args.pack
+    else:
+        base = os.path.join(args.dir, f"bench_{args.size_gb:.0f}gb.flashpack")
+        if not os.path.exists(base):
+            build_pack(base, args.size_gb)
+
+    print(
+        f"\nfile={base} size={os.path.getsize(base) / GB:.2f} GB "
+        f"gpu={torch.cuda.get_device_name(0)} mode={'cold' if args.cold else 'warm'}\n",
+        flush=True,
+    )
+
+    if not args.cold:
+        # warm-up pass so the first row isn't the one paying cache population
+        with open(base, "rb") as f:
+            while f.read(256 * 1024 * 1024):
+                pass
+
+    copies: list[str] = []
+    try:
+        for k, variant in enumerate(args.variants):
+            path = base
+            if args.cold:
+                path = f"{base}.cold{k}"
+                shutil.copyfile(base, path)
+                copies.append(path)
+                if not evict_page_cache(path):
+                    sys.exit(f"failed to evict page cache for {path}; aborting")
+            bench_one(path, variant, cold=args.cold, do_verify=not args.no_verify)
+    finally:
+        for c in copies:
+            try:
+                os.remove(c)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flashpack/commands.py
+++ b/src/flashpack/commands.py
@@ -229,9 +229,9 @@ def convert_to_flashpack(
         if destination_path is None:
             destination_path = os.path.join(model_dir, "model.flashpack")
     else:
-        assert (
-            destination_path is not None
-        ), "destination_path is required when model_or_state_dict_or_path_or_repo_id is repo_id"
+        assert destination_path is not None, (
+            "destination_path is required when model_or_state_dict_or_path_or_repo_id is repo_id"
+        )
         os.makedirs(destination_path, exist_ok=True)
 
         if not use_transformers and not use_diffusers:

--- a/src/flashpack/commands.py
+++ b/src/flashpack/commands.py
@@ -229,9 +229,9 @@ def convert_to_flashpack(
         if destination_path is None:
             destination_path = os.path.join(model_dir, "model.flashpack")
     else:
-        assert destination_path is not None, (
-            "destination_path is required when model_or_state_dict_or_path_or_repo_id is repo_id"
-        )
+        assert (
+            destination_path is not None
+        ), "destination_path is required when model_or_state_dict_or_path_or_repo_id is repo_id"
         os.makedirs(destination_path, exist_ok=True)
 
         if not use_transformers and not use_diffusers:

--- a/src/flashpack/deserialization.py
+++ b/src/flashpack/deserialization.py
@@ -200,6 +200,26 @@ def _copy_memmaps_into_storage(
     chunk_bytes: int,
     num_streams: int,
 ) -> None:
+    # Drain the copy streams even on error: an exception escaping while
+    # non-blocking H2D copies are still in flight lets the caller free the
+    # destination blocks, which the caching allocator may hand to a retry
+    # while the copy engine is still writing — silent weight corruption.
+    try:
+        _copy_memmaps_into_storage_inner(
+            memmaps, specs, storage, device, chunk_bytes, num_streams
+        )
+    finally:
+        torch.cuda.synchronize(device)
+
+
+def _copy_memmaps_into_storage_inner(
+    memmaps: list[np.memmap],
+    specs: list[MacroblockSpec],
+    storage: FlashTensorStorage,
+    device: torch.device,
+    chunk_bytes: int,
+    num_streams: int,
+) -> None:
     for idx, (mm, spec) in enumerate(zip(memmaps, specs)):
         total_elems = spec.length_elems
         elem_sz = torch.tensor([], dtype=spec.dtype).element_size()

--- a/src/flashpack/parallel_read.py
+++ b/src/flashpack/parallel_read.py
@@ -175,6 +175,32 @@ def _read_chunk(fd_direct, fd_plain: int, view, f_off: int, ln: int) -> None:
         got += n
 
 
+def _plan_chunks(
+    specs: "list[MacroblockSpec]", chunk_bytes: int
+) -> list[tuple[int, int, int, int]]:
+    """(block_idx, file_offset, block_offset, length) chunks covering every
+    macroblock. Every chunk after a macroblock's (sub-page) head starts
+    4K-aligned in file space and at position 0 of its staging buffer —
+    satisfying both O_DIRECT alignment requirements.
+    """
+    chunks: list[tuple[int, int, int, int]] = []
+    for idx, spec in enumerate(specs):
+        b_off = 0
+        remaining = spec.length_bytes
+        head = (-spec.offset_bytes) % _ALIGN
+        if head:
+            head = min(head, remaining)
+            chunks.append((idx, spec.offset_bytes, 0, head))
+            b_off += head
+            remaining -= head
+        while remaining > 0:
+            ln = min(chunk_bytes, remaining)
+            chunks.append((idx, spec.offset_bytes + b_off, b_off, ln))
+            b_off += ln
+            remaining -= ln
+    return chunks
+
+
 def parallel_read_into_storage(
     path: str,
     specs: "list[MacroblockSpec]",
@@ -192,27 +218,19 @@ def parallel_read_into_storage(
 
     byte_views = [b.view(torch.uint8) for b in blocks]
 
-    # Plan chunks so every chunk after a macroblock's (sub-page) head starts
-    # 4K-aligned in file space and at position 0 of its staging buffer —
-    # satisfying both O_DIRECT alignment requirements.
+    # The destination blocks were allocated on the caller's current stream;
+    # order every reader stream after that allocation so the caching
+    # allocator cannot hand the readers memory whose prior (default-stream)
+    # work is still pending — the documented wait_event pattern. Free: one
+    # event, recorded once.
+    alloc_ready = torch.cuda.Event()
+    alloc_ready.record(torch.cuda.current_stream(device))
+
     work: queue.SimpleQueue = queue.SimpleQueue()
-    n_chunks = 0
-    for idx, spec in enumerate(specs):
-        b_off = 0
-        remaining = spec.length_bytes
-        head = (-spec.offset_bytes) % _ALIGN
-        if head:
-            head = min(head, remaining)
-            work.put((idx, spec.offset_bytes, 0, head))
-            n_chunks += 1
-            b_off += head
-            remaining -= head
-        while remaining > 0:
-            ln = min(chunk_bytes, remaining)
-            work.put((idx, spec.offset_bytes + b_off, b_off, ln))
-            n_chunks += 1
-            b_off += ln
-            remaining -= ln
+    chunks = _plan_chunks(specs, chunk_bytes)
+    for chunk in chunks:
+        work.put(chunk)
+    n_chunks = len(chunks)
 
     n_threads = min(n_threads, max(1, n_chunks))
     for _ in range(n_threads):
@@ -240,6 +258,7 @@ def parallel_read_into_storage(
                 except OSError:
                     fd_direct = None
             stream = torch.cuda.Stream(device=device)
+            stream.wait_event(alloc_ready)
             bufs = pool[thread_idx]
             # O_DIRECT also requires 4K-aligned user buffers; pinned
             # allocations are page-aligned in practice, but verify.

--- a/tests/test_parallel_read.py
+++ b/tests/test_parallel_read.py
@@ -1,0 +1,106 @@
+"""Unit tests for the parallel O_DIRECT read path (CPU-testable pieces; the
+full CUDA pipeline is exercised by scripts/bench_load_parallel.py on a GPU
+host)."""
+
+import os
+
+import pytest
+import torch
+
+from flashpack.deserialization import MacroblockSpec
+from flashpack.parallel_read import (
+    _ALIGN,
+    _plan_chunks,
+    _read_chunk,
+    parallel_read_supported,
+)
+
+
+def _spec(offset: int, nbytes: int) -> MacroblockSpec:
+    return MacroblockSpec(
+        dtype=torch.uint8, offset_bytes=offset, length_bytes=nbytes, length_elems=nbytes
+    )
+
+
+class TestPlanChunks:
+    @pytest.mark.parametrize(
+        "specs",
+        [
+            [_spec(0, 200 * 1024 * 1024)],  # aligned single block
+            [_spec(100, 64 * 1024 * 1024)],  # unaligned head
+            [_spec(0, 10), _spec(4096, 5000), _spec(9216, 3)],  # tiny blocks
+            [_spec(128, 300_000_007)],  # unaligned + non-round size
+        ],
+    )
+    def test_chunks_cover_each_block_exactly(self, specs) -> None:
+        chunk_bytes = 64 * 1024 * 1024
+        chunks = _plan_chunks(specs, chunk_bytes)
+        for idx, spec in enumerate(specs):
+            mine = [c for c in chunks if c[0] == idx]
+            # contiguous in block space, starting at 0, covering length_bytes
+            assert mine[0][2] == 0
+            pos = 0
+            for _, f_off, b_off, ln in mine:
+                assert b_off == pos
+                assert f_off == spec.offset_bytes + b_off
+                assert 0 < ln <= chunk_bytes
+                pos += ln
+            assert pos == spec.length_bytes
+
+    def test_odirect_alignment_invariant(self) -> None:
+        # every chunk except a block's sub-page head starts 4K-aligned in file
+        # space (the O_DIRECT requirement _read_chunk relies on)
+        specs = [_spec(100, 300 * 1024 * 1024), _spec(4096, 5)]
+        chunks = _plan_chunks(specs, 64 * 1024 * 1024)
+        for idx, spec in enumerate(specs):
+            mine = [c for c in chunks if c[0] == idx]
+            head = (-spec.offset_bytes) % _ALIGN
+            for k, (_, f_off, b_off, ln) in enumerate(mine):
+                if head and k == 0:
+                    assert ln == min(head, spec.length_bytes)
+                else:
+                    assert f_off % _ALIGN == 0
+
+    def test_no_chunk_exceeds_chunk_bytes(self) -> None:
+        chunks = _plan_chunks([_spec(0, 1_000_000)], 4096)
+        assert all(c[3] <= 4096 for c in chunks)
+
+
+class TestReadChunk:
+    def test_buffered_read_exact_bytes(self, tmp_path) -> None:
+        payload = bytes(range(256)) * 512  # 128 KiB
+        f = tmp_path / "blob.bin"
+        f.write_bytes(payload)
+        fd = os.open(str(f), os.O_RDONLY)
+        try:
+            buf = torch.empty(65536, dtype=torch.uint8)
+            view = memoryview(buf.numpy())
+            _read_chunk(None, fd, view, 777, 65536)
+            assert bytes(view[:65536]) == payload[777 : 777 + 65536]
+        finally:
+            os.close(fd)
+
+    def test_short_file_raises(self, tmp_path) -> None:
+        f = tmp_path / "short.bin"
+        f.write_bytes(b"x" * 16)
+        fd = os.open(str(f), os.O_RDONLY)
+        try:
+            buf = torch.empty(64, dtype=torch.uint8)
+            with pytest.raises(IOError):
+                _read_chunk(None, fd, memoryview(buf.numpy()), 0, 64)
+        finally:
+            os.close(fd)
+
+
+class TestSupported:
+    def test_env_opt_out(self, monkeypatch) -> None:
+        monkeypatch.setenv("FLASHPACK_PARALLEL_READ", "0")
+        assert not parallel_read_supported(torch.device("cuda"))
+
+    def test_cuda_posix_default_on(self, monkeypatch) -> None:
+        monkeypatch.delenv("FLASHPACK_PARALLEL_READ", raising=False)
+        assert parallel_read_supported(torch.device("cuda")) == (os.name == "posix")
+
+    def test_cpu_never(self, monkeypatch) -> None:
+        monkeypatch.delenv("FLASHPACK_PARALLEL_READ", raising=False)
+        assert not parallel_read_supported(torch.device("cpu"))

--- a/tests/test_parallel_read.py
+++ b/tests/test_parallel_read.py
@@ -6,7 +6,6 @@ import os
 
 import pytest
 import torch
-
 from flashpack.deserialization import MacroblockSpec
 from flashpack.parallel_read import (
     _ALIGN,


### PR DESCRIPTION
> **Restructured after #24 merged.** This PR originally carried an independent parallel loader (threaded `preadv` → pinned double-buffers → per-stream H2D). @jfischoff's #24 landed an equivalent-or-better core (O_DIRECT + adaptive `mincore` + pooled pinned staging) while this was in review, and a head-to-head on real prod artifacts (below) confirmed #24 wins the regime that matters. This PR is now **hardening + tests + benchmark tooling on top of #24**, plus the v0.3.1 version cut (v0.3.0 was released today with #24 itself).

## What (3 commits on top of #24)

1. **Fix: order reader streams after storage allocation** (`parallel_read.py`) — destination blocks are allocated on the caller's current stream but written on per-reader side streams with no inter-stream ordering; in a warm process the caching allocator can hand the readers memory whose prior default-stream work is still pending (silent corruption window). One event recorded at allocation, every reader stream `wait_event`s it. Also extracts the inline chunk planner into `_plan_chunks()` (pure function, no behavior change) for testability.
2. **Fix: drain in-flight H2D copies when the legacy CUDA path errors** (`deserialization.py`) — an exception escaping `_copy_memmaps_into_storage` (e.g. transient EIO on a network mount) left non-blocking H2D copies in flight into blocks the caller frees; a catch-and-retry can then load silently corrupted weights. #24's parallel path already synchronizes before re-raising; this gives the legacy fallback (`FLASHPACK_PARALLEL_READ=0`) the same guarantee.
3. **Tests + benchmark harness** — first unit tests for `parallel_read` (chunk coverage/contiguity, the O_DIRECT 4K-alignment invariant, `_read_chunk` buffered path + short-read error, env gating) and `scripts/bench_load_parallel.py`: legacy vs parallel vs parallel-buffered on synthetic or real packs, honest cold methodology (fresh per-measurement file copies + `POSIX_FADV_DONTNEED`; cold/warm-labeled rows), per-variant bit-verification against the CPU reference.

## Benchmark

### Does #25 change performance vs main (post-#24)? — No (that's the point)

14 paired runners (7 apps x {main, #25}, one wheel per runner), warm + evicted x2, seconds:

| artifact | size | main warm/evict | #25 warm/evict | evicted ratio #25/main |
|---|---|---|---|---|
| longcat-video | 25.3 GB | 3.53 / 3.46 | 3.46 / 3.52 | 1.02 |
| qwen-edit-2509 | 15.5 GB | 2.71 / 3.05 | 3.06 / 3.14 | 1.03 |
| seedvr2-7b | 15.4 GB | 3.00 / 2.73 | 1.98 / 2.05 | 0.75 |
| firered-int8 | 25.4 GB | 3.53 / 3.55 | 2.60 / 2.62 | 0.74 |
| qwen-image-2512 | 25.4 GB | 2.64 / 2.45 | 3.52 / 3.43 | 1.40 |
| emu3.5-image | 63.5 GB | 4.80 / 4.85 | 6.68 / 6.22 | 1.28 |
| ltx-2 | 35.2 GB | 2.64 / 2.68 | 4.39 / 4.01 | 1.50 |

**Geometric mean of evicted ratios: 1.07 — parity.** Within-runner repeats are ±1–3% while cross-host spread is ±50% in both directions (2 apps favor #25, 2 favor main, 3 tie): the spread is host lottery (JuiceFS local-cache state), not the wheel. Mechanistically #25 adds one event record + one `wait_event` per reader stream at startup — nothing on the hot path. 7/7 apps: main and #25 load byte-identical weights.

### True cold, separate runners

6 big models x {main, #25}: one fresh H100 runner + one single-use `/data` copy per cell (fresh copy = guaranteed cold on JuiceFS; the timed load is the first byte the job touches). Seconds:

| artifact | size | main | #25 | ratio |
|---|---|---|---|---|
| emu3.5-image | 63.5 GB | 99.4 | 98.4 | 0.99 |
| ltx-2 | 35.2 GB | 60.2 | 59.5 | 0.99 |
| firered-int8 | 25.4 GB | 54.3 | 49.8 | 0.92 |
| qwen-image-2512 | 25.4 GB | 45.8 | 46.3 | 1.01 |
| longcat-video | 25.3 GB | 82.3 \* | 47.5 | — |
| seedvr2-7b | 15.4 GB | 36.1 | 34.6 | 0.96 |

**Geometric mean 0.97 — parity**, on 35–100 s loads where host jitter is amortized. All 6 pairs byte-identical. \* longcat's main runner landed on a slow host (0.31 GB/s vs 0.42–0.65 on every other row) — excluded from the mean.


## Decisions

1. **fal-only support posture** — flashpack is developed for the fal fleet (Linux runners); no non-POSIX fallbacks.
2. **One parallel loader, #24's** — decided on the head-to-head data above after both implementations existed; the alternative loader and its `ingest` API surface were dropped rather than maintained in parallel.
3. **Correctness gates ship with the loader** — the two stream-ordering/error-path fixes above, found by adversarial review of the equivalent implementation, apply to the merged code and its fallback.
4. **This PR is v0.3.1** — a patch release on top of #24's v0.3.0 (fixes, tests, tooling; no API change). Tag `v0.3.1` on merge (setuptools-scm).
5. **Validation-first** — benchmark harness with honest cold methodology and per-variant bit-verification is committed, not just quoted.

## Rollback

`FLASHPACK_PARALLEL_READ=0` (env, per process) → legacy path, which after this PR drains correctly on errors. `FLASHPACK_DIRECT_IO=0` keeps parallel reads but buffered.

## Follow-up (registry, separate PR)

Bump registry pins `flashpack==0.2.2` → `==0.3.1` after the release tag; the flashpack skill docs' version references are updated in the registry tree alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

