### PR TITLE
test: add CI-run unit test suite + parallel_read integrity harness

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: pytest (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12"]
+        include:
+          # pack_to_file has Windows-specific behavior (see #17); keep one
+          # Windows job to guard it.
+          - os: windows-latest
+            python-version: "3.12"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # setuptools-scm derives the package version from git tags.
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install CPU-only torch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+      - name: Install flashpack
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        # gpu/network tiers need a CUDA host and Hub downloads; CI runs the
+        # hermetic CPU tier.
+        run: pytest -m "not gpu and not network" -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,10 @@ dev = [
 
 [tool.setuptools_scm]
 write_to = "src/flashpack/version.py"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "gpu: requires a CUDA device (skipped automatically when unavailable)",
+    "network: downloads model weights from the Hugging Face Hub",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Shared pytest configuration.
+
+Markers split the suite into tiers:
+
+* unmarked -- hermetic CPU-only unit tests; these run on every push/PR via
+  ``.github/workflows/test.yaml``.
+* ``gpu`` -- requires a CUDA device; skipped automatically when CUDA is
+  unavailable.
+* ``network`` -- downloads model weights from the Hugging Face Hub; excluded
+  from CI, run manually on a suitable host.
+"""
+
+import pytest
+import torch
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if item.get_closest_marker("gpu") is not None and not torch.cuda.is_available():
+        pytest.skip("test requires a CUDA device")

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,6 +1,5 @@
 import gc
 import os
-import tempfile
 
 import pytest
 import torch
@@ -84,9 +83,13 @@ def test_mixed_dtype_roundtrip(tmp_path) -> None:
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
-def test_load_unload() -> None:
+def test_load_unload(tmp_path) -> None:
     """
     Test that we can load and unload a model from a flash pack file.
+
+    Uses pytest's ``tmp_path`` (deferred, error-tolerant cleanup) rather than
+    ``TemporaryDirectory``: CPU loads keep the pack memory-mapped, and Windows
+    refuses to delete a file with a live mapping.
     """
 
     class TestModel(torch.nn.Module, FlashPackMixin):
@@ -99,14 +102,13 @@ def test_load_unload() -> None:
 
     model = TestModel(10)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = os.path.join(tmpdir, "model.flashpack")
-        model.save_flashpack(path, target_dtype=torch.float32)
-        model2 = TestModel.from_flashpack(path, num_blocks=10)
-        assert model2.conv.weight.shape == model.conv.weight.shape
-        assert torch.allclose(model2.conv.weight, model.conv.weight)
-        assert model2.blocks[0].weight.shape == model.blocks[0].weight.shape
-        assert torch.allclose(model2.blocks[0].weight, model.blocks[0].weight)
+    path = os.path.join(tmp_path, "model.flashpack")
+    model.save_flashpack(path, target_dtype=torch.float32)
+    model2 = TestModel.from_flashpack(path, num_blocks=10)
+    assert model2.conv.weight.shape == model.conv.weight.shape
+    assert torch.allclose(model2.conv.weight, model.conv.weight)
+    assert model2.blocks[0].weight.shape == model.blocks[0].weight.shape
+    assert torch.allclose(model2.blocks[0].weight, model.blocks[0].weight)
 
 
 @pytest.mark.network

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -2,6 +2,7 @@ import gc
 import os
 import tempfile
 
+import pytest
 import torch
 import tqdm
 from flashpack import FlashPackMixin
@@ -108,6 +109,7 @@ def test_load_unload() -> None:
         assert torch.allclose(model2.blocks[0].weight, model.blocks[0].weight)
 
 
+@pytest.mark.network
 def test_wan_transformer() -> None:
     """
     Tests a WanTransformer3D model.
@@ -181,6 +183,7 @@ def test_wan_transformer() -> None:
     gc.collect()
 
 
+@pytest.mark.network
 def test_wan_text_encoder() -> None:
     """
     Tests a WanTransformer3D model.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,116 @@
+"""Tests for the ``flashpack`` command-line interface."""
+
+import json
+
+import pytest
+import safetensors.torch
+import torch
+from click.testing import CliRunner
+from flashpack.__main__ import main
+from flashpack.deserialization import is_flashpack_file
+from flashpack.serialization import pack_to_file
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture()
+def packed_file(tmp_path) -> str:
+    path = str(tmp_path / "model.flashpack")
+    pack_to_file(
+        {"weight": torch.randn(8, 4), "bias": torch.randn(8)},
+        path,
+        target_dtype=None,
+    )
+    return path
+
+
+@pytest.fixture()
+def packed_v4_file(tmp_path) -> str:
+    path = str(tmp_path / "mixed.flashpack")
+    pack_to_file(
+        {"a": torch.randn(8), "b": torch.randn(8).to(torch.bfloat16)},
+        path,
+        target_dtype=None,
+    )
+    return path
+
+
+def test_version(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+
+
+class TestMetadataCommand:
+    def test_plain_output(self, runner: CliRunner, packed_file: str) -> None:
+        result = runner.invoke(main, ["metadata", packed_file])
+        assert result.exit_code == 0
+        assert "format" in result.output
+        assert "index" not in result.output
+
+    def test_json_output(self, runner: CliRunner, packed_file: str) -> None:
+        result = runner.invoke(main, ["metadata", packed_file, "--json"])
+        assert result.exit_code == 0
+        meta = json.loads(result.output)
+        assert meta["format"] == "flashpack_v3"
+        assert "index" not in meta
+
+    def test_json_output_with_index(self, runner: CliRunner, packed_file: str) -> None:
+        result = runner.invoke(
+            main, ["metadata", packed_file, "--json", "--show-index"]
+        )
+        assert result.exit_code == 0
+        meta = json.loads(result.output)
+        assert {rec["name"] for rec in meta["index"]} == {"weight", "bias"}
+
+    def test_v4_macroblocks_output(
+        self, runner: CliRunner, packed_v4_file: str
+    ) -> None:
+        result = runner.invoke(main, ["metadata", packed_v4_file, "--show-index"])
+        assert result.exit_code == 0
+        assert "macroblocks" in result.output
+
+    def test_non_flashpack_file_fails(self, runner: CliRunner, tmp_path) -> None:
+        garbage = tmp_path / "garbage.bin"
+        garbage.write_bytes(b"\0" * 64)
+        result = runner.invoke(main, ["metadata", str(garbage)])
+        assert result.exit_code != 0
+
+    def test_missing_file_fails(self, runner: CliRunner, tmp_path) -> None:
+        result = runner.invoke(main, ["metadata", str(tmp_path / "nope.flashpack")])
+        assert result.exit_code != 0
+
+
+class TestConvertCommand:
+    def test_safetensors_to_flashpack(self, runner: CliRunner, tmp_path) -> None:
+        source_path = str(tmp_path / "model.safetensors")
+        safetensors.torch.save_file({"weight": torch.randn(4, 4)}, source_path)
+        destination = str(tmp_path / "model.flashpack")
+
+        result = runner.invoke(main, ["convert", source_path, destination])
+        assert result.exit_code == 0
+        assert "Success" in result.output
+        assert is_flashpack_file(destination)
+
+    def test_repo_id_without_destination_fails(self, runner: CliRunner) -> None:
+        result = runner.invoke(main, ["convert", "not-a-file/not-a-repo"])
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+class TestRevertCommand:
+    def test_revert_to_safetensors(
+        self, runner: CliRunner, packed_file: str, tmp_path
+    ) -> None:
+        destination = str(tmp_path / "reverted.safetensors")
+        result = runner.invoke(main, ["revert", packed_file, destination])
+        assert result.exit_code == 0
+        assert "Success" in result.output
+        state_dict = safetensors.torch.load_file(destination)
+        assert set(state_dict) == {"weight", "bias"}
+
+    def test_missing_file_fails(self, runner: CliRunner, tmp_path) -> None:
+        result = runner.invoke(main, ["revert", str(tmp_path / "nope.flashpack")])
+        assert result.exit_code != 0

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,133 @@
+"""Unit tests for the conversion helpers in flashpack.commands (file-based
+paths only; repo-id paths need network access and are covered elsewhere)."""
+
+import pytest
+import safetensors.torch
+import torch
+from flashpack.commands import (
+    convert_to_flashpack,
+    convert_to_flashpack_from_state_dict,
+    convert_to_flashpack_from_state_dict_file,
+    filter_kwargs_for_method,
+    revert_from_flashpack,
+)
+from flashpack.deserialization import (
+    get_flashpack_file_metadata,
+    is_flashpack_file,
+    revert_from_file,
+)
+from flashpack.serialization import pack_to_file
+
+
+def _state_dict() -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(0)
+    return {
+        "weight": torch.randn(8, 4, generator=generator),
+        "bias": torch.randn(8, generator=generator),
+    }
+
+
+class TestFilterKwargsForMethod:
+    def test_filters_to_signature(self) -> None:
+        def method(a: int, b: int = 0) -> None:
+            pass
+
+        assert filter_kwargs_for_method({"a": 1, "b": 2, "c": 3}, method) == {
+            "a": 1,
+            "b": 2,
+        }
+
+    def test_var_keyword_passes_everything(self) -> None:
+        def method(a: int, **kwargs) -> None:
+            pass
+
+        kwargs = {"a": 1, "anything": 2}
+        assert filter_kwargs_for_method(kwargs, method) == kwargs
+
+
+class TestConvertFromStateDict:
+    def test_roundtrip(self, tmp_path) -> None:
+        source = _state_dict()
+        destination = str(tmp_path / "model.flashpack")
+        result = convert_to_flashpack_from_state_dict(source, destination)
+        assert result == destination
+        state_dict = revert_from_file(destination)
+        for name, tensor in source.items():
+            assert torch.equal(state_dict[name], tensor)
+
+    def test_dtype_as_string(self, tmp_path) -> None:
+        destination = str(tmp_path / "model.flashpack")
+        convert_to_flashpack_from_state_dict(
+            _state_dict(), destination, dtype="bfloat16"
+        )
+        meta = get_flashpack_file_metadata(destination)
+        assert meta["target_dtype"] == "bfloat16"
+
+    def test_ignore_filters_applied(self, tmp_path) -> None:
+        destination = str(tmp_path / "model.flashpack")
+        convert_to_flashpack_from_state_dict(
+            _state_dict(), destination, ignore_names=["bias"]
+        )
+        meta = get_flashpack_file_metadata(destination)
+        assert [rec["name"] for rec in meta["index"]] == ["weight"]
+
+
+class TestConvertFromStateDictFile:
+    def test_safetensors_input(self, tmp_path) -> None:
+        source = _state_dict()
+        source_path = str(tmp_path / "model.safetensors")
+        safetensors.torch.save_file(source, source_path)
+
+        destination = str(tmp_path / "model.flashpack")
+        convert_to_flashpack_from_state_dict_file(source_path, destination)
+        state_dict = revert_from_file(destination)
+        for name, tensor in source.items():
+            assert torch.equal(state_dict[name], tensor)
+
+    def test_torch_save_input(self, tmp_path) -> None:
+        source = _state_dict()
+        source_path = str(tmp_path / "model.pt")
+        torch.save(source, source_path)
+
+        destination = str(tmp_path / "model.flashpack")
+        convert_to_flashpack_from_state_dict_file(source_path, destination)
+        state_dict = revert_from_file(destination)
+        for name, tensor in source.items():
+            assert torch.equal(state_dict[name], tensor)
+
+
+class TestConvertDispatch:
+    def test_file_input_defaults_destination(self, tmp_path) -> None:
+        source_path = str(tmp_path / "model.safetensors")
+        safetensors.torch.save_file(_state_dict(), source_path)
+
+        result = convert_to_flashpack(source_path)
+        assert result == str(tmp_path / "model.flashpack")
+        assert is_flashpack_file(result)
+
+    def test_repo_id_without_destination_rejected(self) -> None:
+        with pytest.raises(AssertionError, match="destination_path is required"):
+            convert_to_flashpack("not-a-file/definitely-not-a-repo")
+
+
+class TestRevertFromFlashpack:
+    def test_default_safetensors_destination(self, tmp_path) -> None:
+        source = _state_dict()
+        pack_path = str(tmp_path / "model.flashpack")
+        pack_to_file(source, pack_path, target_dtype=None)
+
+        result = revert_from_flashpack(pack_path)
+        assert result == str(tmp_path / "model.safetensors")
+        state_dict = safetensors.torch.load_file(result)
+        for name, tensor in source.items():
+            assert torch.equal(state_dict[name], tensor)
+
+    def test_torch_save_destination(self, tmp_path) -> None:
+        source = _state_dict()
+        pack_path = str(tmp_path / "model.flashpack")
+        pack_to_file(source, pack_path, target_dtype=None)
+
+        result = revert_from_flashpack(pack_path, str(tmp_path / "model.pt"))
+        state_dict = torch.load(result, weights_only=True)
+        for name, tensor in source.items():
+            assert torch.equal(state_dict[name], tensor)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,0 +1,260 @@
+"""Unit tests for reading flashpack files: footer parsing, corrupt-file
+handling, tensor iteration, and state-dict / module assignment."""
+
+import json
+
+import pytest
+import torch
+from flashpack.constants import MAGIC, U64LE
+from flashpack.deserialization import (
+    assign_from_file,
+    get_flashpack_file_metadata,
+    is_flashpack_file,
+    iterate_from_flash_tensor,
+    read_flashpack_file,
+    revert_from_file,
+)
+from flashpack.serialization import pack_to_file
+
+
+class SmallModel(torch.nn.Module):
+    def __init__(self, features: int = 8) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(features, features)
+        self.register_buffer("scale", torch.full((features,), 2.0))
+
+
+def _pack(tmp_path, state_dict_or_model, **kwargs) -> str:
+    path = str(tmp_path / "pack.flashpack")
+    kwargs.setdefault("target_dtype", None)
+    pack_to_file(state_dict_or_model, path, **kwargs)
+    return path
+
+
+class TestMetadata:
+    def test_reads_back_index(self, tmp_path) -> None:
+        path = _pack(tmp_path, {"a": torch.randn(4, 2), "b": torch.randn(3)})
+        meta = get_flashpack_file_metadata(path)
+        by_name = {rec["name"]: rec for rec in meta["index"]}
+        assert by_name["a"]["shape"] == [4, 2]
+        assert by_name["a"]["length"] == 8
+        assert by_name["b"]["shape"] == [3]
+
+    def test_file_too_small(self, tmp_path) -> None:
+        path = tmp_path / "small.bin"
+        path.write_bytes(b"tiny")
+        with pytest.raises(ValueError, match="File too small"):
+            get_flashpack_file_metadata(str(path))
+
+    def test_bad_magic(self, tmp_path) -> None:
+        path = tmp_path / "bad.bin"
+        path.write_bytes(b"\0" * 64)
+        with pytest.raises(ValueError, match="Bad magic"):
+            get_flashpack_file_metadata(str(path))
+
+    def test_corrupt_footer_length(self, tmp_path) -> None:
+        path = tmp_path / "corrupt.bin"
+        # Valid magic, but the footer length points beyond the file start.
+        path.write_bytes(b"\0" * 8 + U64LE.pack(10_000) + MAGIC)
+        with pytest.raises(ValueError, match="Corrupt footer length"):
+            get_flashpack_file_metadata(str(path))
+
+    def test_unexpected_format(self, tmp_path) -> None:
+        payload = json.dumps({"format": "flashpack_v999"}).encode()
+        path = tmp_path / "future.bin"
+        path.write_bytes(payload + U64LE.pack(len(payload)) + MAGIC)
+        with pytest.raises(ValueError, match="Unexpected format"):
+            get_flashpack_file_metadata(str(path))
+
+    def test_is_flashpack_file(self, tmp_path) -> None:
+        packed = _pack(tmp_path, {"a": torch.randn(4)})
+        garbage = tmp_path / "garbage.bin"
+        garbage.write_bytes(b"\0" * 64)
+        assert is_flashpack_file(packed) is True
+        assert is_flashpack_file(str(garbage)) is False
+        assert is_flashpack_file(str(tmp_path / "does-not-exist")) is False
+
+
+class TestReadFlashpackFile:
+    def test_cpu_read(self, tmp_path) -> None:
+        path = _pack(tmp_path, {"a": torch.randn(4)})
+        storage, meta = read_flashpack_file(path, device="cpu")
+        assert storage.device.type == "cpu"
+        assert len(storage) == 1
+
+    def test_unsupported_device(self, tmp_path) -> None:
+        path = _pack(tmp_path, {"a": torch.randn(4)})
+        with pytest.raises(ValueError, match="Unsupported device"):
+            read_flashpack_file(path, device="meta")
+
+
+class TestIterate:
+    def test_yields_original_values_and_shapes(self, tmp_path) -> None:
+        source = {"a": torch.randn(4, 2), "b": torch.randn(3)}
+        storage, meta = read_flashpack_file(_pack(tmp_path, source))
+        tensors = dict(iterate_from_flash_tensor(storage, meta))
+        assert set(tensors) == {"a", "b"}
+        for name, tensor in source.items():
+            assert tensors[name].shape == tensor.shape
+            assert torch.equal(tensors[name], tensor)
+
+    def test_ignore_filters(self, tmp_path) -> None:
+        source = {
+            "keep.weight": torch.randn(2),
+            "rope.freqs": torch.randn(2),
+            "drop.bias": torch.randn(2),
+        }
+        storage, meta = read_flashpack_file(_pack(tmp_path, source))
+        names = {
+            name
+            for name, _ in iterate_from_flash_tensor(
+                storage, meta, ignore_prefixes=["rope"], ignore_suffixes=[".bias"]
+            )
+        }
+        assert names == {"keep.weight"}
+
+    def test_invalid_macroblock_reference_rejected(self, tmp_path) -> None:
+        storage, meta = read_flashpack_file(_pack(tmp_path, {"a": torch.randn(4)}))
+        meta["index"][0]["macroblock"] = 5
+        with pytest.raises(ValueError, match="macroblock"):
+            list(iterate_from_flash_tensor(storage, meta))
+
+    def test_misaligned_index_rejected(self, tmp_path) -> None:
+        path = _pack(tmp_path, {"a": torch.randn(8), "b": torch.randn(8)})
+        storage, meta = read_flashpack_file(path)
+        meta["index"][1]["offset"] += 1
+        with pytest.raises(ValueError, match="misaligned"):
+            list(iterate_from_flash_tensor(storage, meta))
+
+    def test_out_of_bounds_record_rejected(self, tmp_path) -> None:
+        storage, meta = read_flashpack_file(_pack(tmp_path, {"a": torch.randn(4)}))
+        meta["index"][0]["length"] = 10_000
+        with pytest.raises(ValueError, match="Could not get tensor"):
+            list(iterate_from_flash_tensor(storage, meta))
+
+
+class TestRevert:
+    def test_roundtrip_matches_source(self, tmp_path) -> None:
+        source = {
+            "a": torch.randn(16, 4),
+            "b": torch.randn(5).to(torch.bfloat16),
+            "c": torch.arange(6, dtype=torch.int64),
+        }
+        state_dict = revert_from_file(_pack(tmp_path, source))
+        assert set(state_dict) == set(source)
+        for name, tensor in source.items():
+            assert state_dict[name].dtype == tensor.dtype
+            assert torch.equal(state_dict[name], tensor)
+
+
+class TestAssignFromFile:
+    def test_assigns_params_and_buffers(self, tmp_path) -> None:
+        torch.manual_seed(0)
+        source = SmallModel()
+        source.scale.mul_(3.0)
+        torch.manual_seed(1)
+        destination = SmallModel()
+        path = _pack(tmp_path, source)
+
+        assign_from_file(destination, path, device="cpu")
+
+        assert torch.equal(destination.linear.weight, source.linear.weight)
+        assert torch.equal(destination.linear.bias, source.linear.bias)
+        assert torch.equal(destination.scale, source.scale)
+
+    def test_device_inferred_from_model(self, tmp_path) -> None:
+        source = SmallModel()
+        destination = SmallModel()
+        assign_from_file(destination, _pack(tmp_path, source), device=None)
+        assert destination.linear.weight.device.type == "cpu"
+
+    def test_requires_grad_preserved(self, tmp_path) -> None:
+        source = SmallModel()
+        destination = SmallModel()
+        destination.linear.weight.requires_grad_(False)
+        assign_from_file(destination, _pack(tmp_path, source), device="cpu")
+        assert destination.linear.weight.requires_grad is False
+        assert destination.linear.bias.requires_grad is True
+
+    def test_missing_param_strict_rejected(self, tmp_path) -> None:
+        class BiggerModel(SmallModel):
+            def __init__(self, features: int = 8) -> None:
+                super().__init__(features)
+                self.extra = torch.nn.Parameter(torch.zeros(features))
+
+        path = _pack(tmp_path, SmallModel())
+        with pytest.raises(ValueError, match="Missing 1 parameters"):
+            assign_from_file(BiggerModel(), path, device="cpu")
+
+    def test_missing_param_allowed_when_not_strict(self, tmp_path) -> None:
+        class BiggerModel(SmallModel):
+            def __init__(self, features: int = 8) -> None:
+                super().__init__(features)
+                self.extra = torch.nn.Parameter(torch.zeros(features))
+
+        path = _pack(tmp_path, SmallModel())
+        destination = BiggerModel()
+        assign_from_file(destination, path, device="cpu", strict_params=False)
+        assert torch.equal(destination.extra, torch.zeros(8))
+
+    def test_unknown_name_in_pack_rejected(self, tmp_path) -> None:
+        source_dict = dict(SmallModel().state_dict())
+        source_dict["unknown.weight"] = torch.randn(4)
+        path = _pack(tmp_path, source_dict)
+        with pytest.raises(ValueError, match="Could not assign"):
+            assign_from_file(SmallModel(), path, device="cpu")
+
+    def test_ignored_names_skipped_and_not_required(self, tmp_path) -> None:
+        source = SmallModel()
+        destination = SmallModel()
+        original_bias = destination.linear.bias.detach().clone()
+        assign_from_file(
+            destination,
+            _pack(tmp_path, source),
+            device="cpu",
+            ignore_names=["linear.bias"],
+        )
+        assert torch.equal(destination.linear.weight, source.linear.weight)
+        assert torch.equal(destination.linear.bias, original_bias)
+
+    def test_buffer_dtype_mismatch_rejected(self, tmp_path) -> None:
+        class DoubleBufferModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(8, 8)
+                self.register_buffer("scale", torch.ones(8, dtype=torch.float64))
+
+        path = _pack(tmp_path, SmallModel())
+        with pytest.raises(ValueError, match="Error while assigning"):
+            assign_from_file(DoubleBufferModel(), path, device="cpu")
+
+    def test_buffer_dtype_mismatch_coerced(self, tmp_path) -> None:
+        class DoubleBufferModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.linear = torch.nn.Linear(8, 8)
+                self.register_buffer("scale", torch.ones(8, dtype=torch.float64))
+
+        source = SmallModel()
+        destination = DoubleBufferModel()
+        assign_from_file(
+            destination, _pack(tmp_path, source), device="cpu", coerce_dtype=True
+        )
+        assert destination.scale.dtype is torch.float64
+        assert torch.equal(destination.scale, source.scale.to(torch.float64))
+
+    def test_keep_flash_ref_on_model(self, tmp_path) -> None:
+        destination = SmallModel()
+        assign_from_file(
+            destination,
+            _pack(tmp_path, SmallModel()),
+            device="cpu",
+            keep_flash_ref_on_model=True,
+        )
+        assert hasattr(destination, "_flash_shared_storage")
+        assert hasattr(destination, "_flash_shared_storage_meta")
+
+    def test_no_flash_ref_by_default(self, tmp_path) -> None:
+        destination = SmallModel()
+        assign_from_file(destination, _pack(tmp_path, SmallModel()), device="cpu")
+        assert not hasattr(destination, "_flash_shared_storage")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,6 +1,11 @@
 import os
 from tempfile import TemporaryDirectory
 
+import pytest
+
+# Both tests download model weights from the Hugging Face Hub.
+pytestmark = pytest.mark.network
+
 
 def test_diffusers() -> None:
     """

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -1,0 +1,147 @@
+"""Unit tests for FlashPackMixin.from_flashpack / save_flashpack behavior."""
+
+import pytest
+import torch
+from flashpack import FlashPackMixin
+
+
+class Model(torch.nn.Module, FlashPackMixin):
+    def __init__(self, features: int = 8) -> None:
+        super().__init__()
+        self.linear = torch.nn.Linear(features, features)
+        self.register_buffer("scale", torch.full((features,), 2.0))
+
+
+def _save(model: torch.nn.Module, tmp_path) -> str:
+    path = str(tmp_path / "model.flashpack")
+    model.save_flashpack(path, target_dtype=None, silent=True)
+    return path
+
+
+def test_roundtrip_preserves_values(tmp_path) -> None:
+    torch.manual_seed(0)
+    source = Model()
+    loaded = Model.from_flashpack(_save(source, tmp_path), features=8, silent=True)
+    assert torch.equal(loaded.linear.weight, source.linear.weight)
+    assert torch.equal(loaded.linear.bias, source.linear.bias)
+    assert torch.equal(loaded.scale, source.scale)
+
+
+def test_device_accepts_string(tmp_path) -> None:
+    path = _save(Model(), tmp_path)
+    loaded = Model.from_flashpack(path, features=8, device="cpu", silent=True)
+    assert loaded.linear.weight.device.type == "cpu"
+
+
+def test_unexpected_kwargs_are_filtered(tmp_path) -> None:
+    """Kwargs not accepted by the init function must be dropped, not raise
+    TypeError (mirrors how integrations forward loose ``from_pretrained``
+    kwargs)."""
+    path = _save(Model(), tmp_path)
+    loaded = Model.from_flashpack(
+        path, features=8, silent=True, not_a_real_kwarg=123, another_one="x"
+    )
+    assert isinstance(loaded, Model)
+
+
+def test_flashpack_init_method_is_used(tmp_path) -> None:
+    class InitMethodModel(torch.nn.Module, FlashPackMixin):
+        flashpack_init_method = "build"
+
+        def __init__(self, features: int = 8, built_via_build: bool = False) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(features, features)
+            self.built_via_build = built_via_build
+
+        @classmethod
+        def build(cls, features: int = 8) -> "InitMethodModel":
+            return cls(features=features, built_via_build=True)
+
+    source = InitMethodModel()
+    path = str(tmp_path / "model.flashpack")
+    source.save_flashpack(path, target_dtype=None, silent=True)
+
+    loaded = InitMethodModel.from_flashpack(path, features=8, silent=True)
+    assert loaded.built_via_build is True
+
+
+def test_explicit_init_fn_wins(tmp_path) -> None:
+    path = _save(Model(), tmp_path)
+    calls: list[int] = []
+
+    def init_fn(features: int = 8) -> Model:
+        calls.append(features)
+        return Model(features=features)
+
+    loaded = Model.from_flashpack(path, features=8, silent=True, init_fn=init_fn)
+    assert isinstance(loaded, Model)
+    assert calls == [8]
+
+
+def test_class_level_ignore_names(tmp_path) -> None:
+    class IgnoringModel(Model):
+        flashpack_ignore_names = ["scale"]
+
+    source = IgnoringModel()
+    source.scale.mul_(21.0)  # pack a value that must NOT be restored
+    path = _save(source, tmp_path)
+
+    loaded = IgnoringModel.from_flashpack(path, features=8, silent=True)
+    # The ignored buffer keeps its __init__ value instead of the packed one.
+    assert torch.equal(loaded.scale, torch.full((8,), 2.0))
+    assert torch.equal(loaded.linear.weight, source.linear.weight)
+
+
+def test_buffer_dtype_mismatch_rejected_without_coercion(tmp_path) -> None:
+    class DoubleBufferModel(torch.nn.Module, FlashPackMixin):
+        def __init__(self, features: int = 8) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(features, features)
+            self.register_buffer("scale", torch.ones(features, dtype=torch.float64))
+
+    path = _save(Model(), tmp_path)
+    with pytest.raises(ValueError, match="Error while assigning"):
+        DoubleBufferModel.from_flashpack(path, features=8, silent=True)
+
+
+def test_flashpack_coerce_dtype_class_flag(tmp_path) -> None:
+    class CoercingModel(torch.nn.Module, FlashPackMixin):
+        flashpack_coerce_dtype = True
+
+        def __init__(self, features: int = 8) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(features, features)
+            self.register_buffer("scale", torch.ones(features, dtype=torch.float64))
+
+    source = Model()
+    path = _save(source, tmp_path)
+
+    loaded = CoercingModel.from_flashpack(path, features=8, silent=True)
+    assert loaded.scale.dtype is torch.float64
+    assert torch.equal(loaded.scale, source.scale.to(torch.float64))
+
+
+def test_keep_flash_ref_on_model(tmp_path) -> None:
+    path = _save(Model(), tmp_path)
+    loaded = Model.from_flashpack(
+        path, features=8, silent=True, keep_flash_ref_on_model=True
+    )
+    assert hasattr(loaded, "_flash_shared_storage")
+    assert hasattr(loaded, "_flash_shared_storage_meta")
+
+
+def test_no_flash_ref_by_default(tmp_path) -> None:
+    path = _save(Model(), tmp_path)
+    loaded = Model.from_flashpack(path, features=8, silent=True)
+    assert not hasattr(loaded, "_flash_shared_storage")
+
+
+def test_missing_param_strict_by_default(tmp_path) -> None:
+    class BiggerModel(Model):
+        def __init__(self, features: int = 8) -> None:
+            super().__init__(features)
+            self.extra = torch.nn.Parameter(torch.zeros(features))
+
+    path = _save(Model(), tmp_path)
+    with pytest.raises(ValueError, match="Missing 1 parameters"):
+        BiggerModel.from_flashpack(path, features=8, silent=True)

--- a/tests/test_parallel_read.py
+++ b/tests/test_parallel_read.py
@@ -65,6 +65,9 @@ class TestPlanChunks:
         assert all(c[3] <= 4096 for c in chunks)
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="_read_chunk uses os.preadv (POSIX-only)"
+)
 class TestReadChunk:
     def test_buffered_read_exact_bytes(self, tmp_path) -> None:
         payload = bytes(range(256)) * 512  # 128 KiB

--- a/tests/test_parallel_read_integrity.py
+++ b/tests/test_parallel_read_integrity.py
@@ -1,0 +1,379 @@
+"""Adversarial integrity tests for the parallel read path.
+
+``parallel_read_into_storage`` targets CUDA, but every stage that could
+*silently corrupt data* is CPU-visible: chunk planning, O_DIRECT/buffered
+read assembly, staging-buffer reuse, thread/queue orchestration, and error
+draining. These tests fake only the CUDA stream/event plumbing and the
+pinned-buffer pool (plain CPU tensors), then run the real reader threads
+against real files and require byte-identical results.
+
+Every payload is position-dependent random data and every gap between
+macroblocks is filled with a sentinel byte, so a chunk landing at the wrong
+destination, a swapped staging buffer, an off-by-one file offset, or a
+dropped tail all fail the equality check.
+
+``test_parallel_matches_legacy_on_cuda`` additionally verifies the real
+CUDA pipeline against the legacy reader on GPU hosts (marked ``gpu``).
+"""
+
+import os
+from contextlib import contextmanager
+
+import numpy as np
+import pytest
+import torch
+from flashpack import parallel_read
+from flashpack.deserialization import MacroblockSpec, read_flashpack_file
+from flashpack.parallel_read import (
+    _ALIGN,
+    _plan_chunks,
+    _read_chunk,
+    parallel_read_into_storage,
+)
+from flashpack.serialization import pack_to_file
+
+GAP_SENTINEL = 0xEE
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="the parallel reader uses os.preadv (POSIX-only)"
+)
+
+
+class _FakeEvent:
+    def record(self, stream=None) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+
+class _FakeStream:
+    def __init__(self, device=None) -> None:
+        self.device = device
+
+    def wait_event(self, event) -> None:
+        pass
+
+    def synchronize(self) -> None:
+        pass
+
+
+class _FakeCuda:
+    Event = _FakeEvent
+    Stream = _FakeStream
+
+    @staticmethod
+    def current_stream(device=None) -> _FakeStream:
+        return _FakeStream(device)
+
+    @staticmethod
+    def synchronize(device=None) -> None:
+        pass
+
+    @staticmethod
+    @contextmanager
+    def stream(stream):
+        yield
+
+
+@pytest.fixture()
+def cpu_parallel_read(monkeypatch):
+    """Run the real parallel reader on CPU: fake the CUDA plumbing, use plain
+    CPU staging buffers, and default O_DIRECT off (tests opt back in)."""
+
+    def fake_pool(n_threads: int, chunk_bytes: int) -> list:
+        return [
+            [torch.empty(chunk_bytes, dtype=torch.uint8) for _ in range(2)]
+            for _ in range(n_threads)
+        ]
+
+    monkeypatch.setattr(parallel_read.torch, "cuda", _FakeCuda)
+    monkeypatch.setattr(parallel_read, "_get_pinned_pool", fake_pool)
+    monkeypatch.setenv("FLASHPACK_DIRECT_IO", "0")
+    # Small defaults keep the fake staging pool tiny; tests override as needed.
+    monkeypatch.setenv("FLASHPACK_READ_THREADS", "4")
+    monkeypatch.setenv("FLASHPACK_READ_CHUNK_BYTES", "8192")
+    return monkeypatch
+
+
+def _make_file(
+    tmp_path, specs: list[MacroblockSpec], seed: int = 0
+) -> tuple[str, bytes]:
+    """Write a file whose payload regions hold position-dependent random
+    bytes and whose gaps hold GAP_SENTINEL."""
+    total = max((s.offset_bytes + s.length_bytes) for s in specs)
+    data = np.full(total, GAP_SENTINEL, dtype=np.uint8)
+    rng = np.random.default_rng(seed)
+    for spec in specs:
+        data[spec.offset_bytes : spec.offset_bytes + spec.length_bytes] = rng.integers(
+            0, 256, spec.length_bytes, dtype=np.uint8
+        )
+    path = str(tmp_path / "payload.bin")
+    with open(path, "wb") as f:
+        f.write(data.tobytes())
+    return path, data.tobytes()
+
+
+def _uint8_spec(offset: int, nbytes: int) -> MacroblockSpec:
+    return MacroblockSpec(
+        dtype=torch.uint8, offset_bytes=offset, length_bytes=nbytes, length_elems=nbytes
+    )
+
+
+def _run_and_verify(path: str, data: bytes, specs: list[MacroblockSpec]) -> None:
+    blocks = [
+        torch.full((spec.length_elems,), 0xAB, dtype=torch.uint8) for spec in specs
+    ]
+    parallel_read_into_storage(path, specs, blocks, torch.device("cpu"))
+    for spec, block in zip(specs, blocks):
+        expected = data[spec.offset_bytes : spec.offset_bytes + spec.length_bytes]
+        assert bytes(block.numpy()) == expected
+
+
+@posix_only
+class TestByteIdentical:
+    def test_single_aligned_block_many_chunks(
+        self, tmp_path, cpu_parallel_read
+    ) -> None:
+        """4 MiB through 4 KiB chunks: ~1000 chunks over 8 threads, hammering
+        staging-buffer reuse and queue ordering."""
+        cpu_parallel_read.setenv("FLASHPACK_READ_THREADS", "8")
+        cpu_parallel_read.setenv("FLASHPACK_READ_CHUNK_BYTES", "4096")
+        specs = [_uint8_spec(0, 4 * 1024 * 1024)]
+        path, data = _make_file(tmp_path, specs)
+        _run_and_verify(path, data, specs)
+
+    def test_unaligned_multiblock_with_gaps(self, tmp_path, cpu_parallel_read) -> None:
+        """Blocks at unaligned offsets separated by sentinel-filled gaps: any
+        off-by-one in file offsets pulls sentinel bytes into a block."""
+        cpu_parallel_read.setenv("FLASHPACK_READ_THREADS", "4")
+        cpu_parallel_read.setenv("FLASHPACK_READ_CHUNK_BYTES", "8192")
+        specs = [
+            _uint8_spec(100, 70_003),
+            _uint8_spec(80_001, 4096),
+            _uint8_spec(90_000, 3),
+            _uint8_spec(94_208, 130_001),  # 4K-aligned start, odd length
+        ]
+        path, data = _make_file(tmp_path, specs)
+        _run_and_verify(path, data, specs)
+
+    @pytest.mark.parametrize("n_threads", [1, 3, 16])
+    @pytest.mark.parametrize("chunk_bytes", [4096, 1 << 20])
+    def test_thread_chunk_matrix(
+        self, tmp_path, cpu_parallel_read, n_threads: int, chunk_bytes: int
+    ) -> None:
+        cpu_parallel_read.setenv("FLASHPACK_READ_THREADS", str(n_threads))
+        cpu_parallel_read.setenv("FLASHPACK_READ_CHUNK_BYTES", str(chunk_bytes))
+        specs = [_uint8_spec(37, 1_000_003), _uint8_spec(1_003_520, 500_000)]
+        path, data = _make_file(tmp_path, specs, seed=n_threads)
+        _run_and_verify(path, data, specs)
+
+    def test_more_threads_than_chunks(self, tmp_path, cpu_parallel_read) -> None:
+        cpu_parallel_read.setenv("FLASHPACK_READ_THREADS", "16")
+        specs = [_uint8_spec(0, 100)]
+        path, data = _make_file(tmp_path, specs)
+        _run_and_verify(path, data, specs)
+
+    def test_zero_length_block_among_others(self, tmp_path, cpu_parallel_read) -> None:
+        specs = [_uint8_spec(0, 8192), _uint8_spec(8192, 0), _uint8_spec(8192, 4096)]
+        path, data = _make_file(tmp_path, specs)
+        _run_and_verify(path, data, specs)
+
+    def test_typed_blocks_roundtrip_bits(self, tmp_path, cpu_parallel_read) -> None:
+        """Non-uint8 destination blocks (bfloat16/float32) must receive the
+        exact payload bits through their uint8 views."""
+        specs = [
+            MacroblockSpec(
+                dtype=torch.bfloat16,
+                offset_bytes=0,
+                length_bytes=8192,
+                length_elems=4096,
+            ),
+            MacroblockSpec(
+                dtype=torch.float32,
+                offset_bytes=8192,
+                length_bytes=40_000,
+                length_elems=10_000,
+            ),
+        ]
+        path, data = _make_file(tmp_path, specs)
+        blocks = [torch.empty(spec.length_elems, dtype=spec.dtype) for spec in specs]
+        parallel_read_into_storage(path, specs, blocks, torch.device("cpu"))
+        for spec, block in zip(specs, blocks):
+            expected = data[spec.offset_bytes : spec.offset_bytes + spec.length_bytes]
+            assert bytes(block.view(torch.uint8).numpy()) == expected
+
+    def test_direct_io_enabled_still_byte_identical(
+        self, tmp_path, cpu_parallel_read
+    ) -> None:
+        """With O_DIRECT allowed, every fallback (unsupported filesystem,
+        unaligned buffers, short direct reads) must stay byte-identical."""
+        cpu_parallel_read.setenv("FLASHPACK_DIRECT_IO", "1")
+        cpu_parallel_read.setenv("FLASHPACK_READ_THREADS", "4")
+        cpu_parallel_read.setenv("FLASHPACK_READ_CHUNK_BYTES", "65536")
+        specs = [_uint8_spec(100, 1_000_000), _uint8_spec(1_003_520, 250_001)]
+        path, data = _make_file(tmp_path, specs)
+        _run_and_verify(path, data, specs)
+
+    def test_partial_reads_assemble_correctly(
+        self, tmp_path, cpu_parallel_read
+    ) -> None:
+        """A filesystem returning short reads (e.g. 1000 bytes at a time) must
+        never drop or misplace bytes — the assembly loop has to resume from
+        the exact file offset it stopped at."""
+        real_preadv = os.preadv
+
+        def short_preadv(fd, buffers, offset):
+            view = buffers[0]
+            capped = [view[: min(1000, len(view))]]
+            return real_preadv(fd, capped, offset)
+
+        cpu_parallel_read.setattr(os, "preadv", short_preadv)
+        specs = [_uint8_spec(37, 300_007)]
+        path, data = _make_file(tmp_path, specs)
+        _run_and_verify(path, data, specs)
+
+
+@posix_only
+class TestErrorsNeverSilent:
+    def test_truncated_file_raises(self, tmp_path, cpu_parallel_read) -> None:
+        """A file shorter than the specs claim must raise, not return
+        partially-filled storage."""
+        specs = [_uint8_spec(0, 100_000)]
+        path, _ = _make_file(tmp_path, specs)
+        with open(path, "r+b") as f:
+            f.truncate(50_000)
+        blocks = [torch.zeros(100_000, dtype=torch.uint8)]
+        with pytest.raises(IOError):
+            parallel_read_into_storage(path, specs, blocks, torch.device("cpu"))
+
+    def test_mid_read_failure_propagates_and_joins(
+        self, tmp_path, cpu_parallel_read
+    ) -> None:
+        """An I/O error on one chunk must propagate to the caller after all
+        reader threads drain — never swallowed."""
+        specs = [_uint8_spec(0, 512 * 1024)]
+        path, _ = _make_file(tmp_path, specs)
+        cpu_parallel_read.setenv("FLASHPACK_READ_THREADS", "4")
+        cpu_parallel_read.setenv("FLASHPACK_READ_CHUNK_BYTES", "4096")
+
+        real_preadv = os.preadv
+        poison_offset = 256 * 1024
+
+        def failing_preadv(fd, buffers, offset):
+            if offset == poison_offset:
+                raise OSError(5, "simulated I/O error")
+            return real_preadv(fd, buffers, offset)
+
+        cpu_parallel_read.setattr(os, "preadv", failing_preadv)
+        blocks = [torch.zeros(512 * 1024, dtype=torch.uint8)]
+        with pytest.raises(OSError, match="simulated I/O error"):
+            parallel_read_into_storage(path, specs, blocks, torch.device("cpu"))
+
+    def test_bogus_direct_fd_falls_back_to_buffered(self, tmp_path) -> None:
+        """OSError on the O_DIRECT descriptor (EBADF here; EINVAL on real
+        filesystems) must degrade to a byte-identical buffered read."""
+        payload = np.random.default_rng(7).integers(0, 256, 128 * 1024, dtype=np.uint8)
+        f = tmp_path / "blob.bin"
+        f.write_bytes(payload.tobytes())
+        fd_plain = os.open(str(f), os.O_RDONLY)
+        bogus_fd_direct = 2**20  # certainly not an open descriptor
+        try:
+            buf = torch.empty(65536, dtype=torch.uint8)
+            view = memoryview(buf.numpy())
+            _read_chunk(bogus_fd_direct, fd_plain, view, 4096, 65536)
+            assert bytes(view[:65536]) == payload.tobytes()[4096 : 4096 + 65536]
+        finally:
+            os.close(fd_plain)
+
+    def test_short_direct_read_completes_buffered(self, tmp_path, monkeypatch) -> None:
+        """A direct descriptor that returns part of the aligned body and then
+        stalls must hand off to the buffered descriptor at the exact resume
+        offset."""
+        payload = np.random.default_rng(11).integers(0, 256, 64 * 1024, dtype=np.uint8)
+        f = tmp_path / "blob.bin"
+        f.write_bytes(payload.tobytes())
+        fd_plain = os.open(str(f), os.O_RDONLY)
+        fd_direct = os.open(str(f), os.O_RDONLY)  # plays the direct role
+
+        real_preadv = os.preadv
+        direct_calls = {"n": 0}
+
+        def stalling_preadv(fd, buffers, offset):
+            if fd == fd_direct:
+                direct_calls["n"] += 1
+                if direct_calls["n"] == 1:
+                    capped = [buffers[0][:_ALIGN]]  # one aligned page, then stall
+                    return real_preadv(fd, capped, offset)
+                return 0
+            return real_preadv(fd, buffers, offset)
+
+        monkeypatch.setattr(os, "preadv", stalling_preadv)
+        try:
+            buf = torch.empty(64 * 1024, dtype=torch.uint8)
+            view = memoryview(buf.numpy())
+            _read_chunk(fd_direct, fd_plain, view, 0, 64 * 1024)
+            assert bytes(view) == payload.tobytes()
+            assert direct_calls["n"] >= 2
+        finally:
+            os.close(fd_plain)
+            os.close(fd_direct)
+
+
+class TestPlanChunksFuzz:
+    @pytest.mark.parametrize("seed", range(50))
+    def test_random_layouts_cover_exactly_once(self, seed: int) -> None:
+        """Chunks must tile every macroblock exactly once — no gaps, no
+        overlap, no bleed across blocks — for arbitrary offsets and sizes."""
+        rng = np.random.default_rng(seed)
+        chunk_bytes = int(rng.choice([4096, 65536, 1 << 20]))
+        cursor = int(rng.integers(0, 5000))
+        specs = []
+        for _ in range(int(rng.integers(1, 8))):
+            cursor += int(rng.integers(0, 10000))
+            length = int(rng.integers(0, 3_000_000))
+            specs.append(_uint8_spec(cursor, length))
+            cursor += length
+
+        chunks = _plan_chunks(specs, chunk_bytes)
+        for idx, spec in enumerate(specs):
+            mine = [c for c in chunks if c[0] == idx]
+            pos = 0
+            for _, f_off, b_off, ln in mine:
+                assert b_off == pos, "gap or overlap in block coverage"
+                assert f_off == spec.offset_bytes + b_off, "file offset drift"
+                assert 0 < ln <= chunk_bytes
+                pos += ln
+            assert pos == spec.length_bytes, "block not fully covered"
+            head = (-spec.offset_bytes) % _ALIGN
+            for k, (_, f_off, _, ln) in enumerate(mine):
+                if not (head and k == 0):
+                    assert f_off % _ALIGN == 0, "O_DIRECT alignment violated"
+
+
+@pytest.mark.gpu
+def test_parallel_matches_legacy_on_cuda(tmp_path, monkeypatch) -> None:
+    """On a real CUDA host, the parallel reader must produce bit-identical
+    storage to the legacy chunked reader for a mixed-dtype pack."""
+    torch.manual_seed(0)
+    state_dict = {
+        "a": torch.randn(1_000_003),
+        "b": torch.randn(2048, 512).to(torch.bfloat16),
+        "c": torch.randint(0, 127, (777_777,), dtype=torch.int8),
+    }
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(state_dict, path, target_dtype=None)
+
+    monkeypatch.setenv("FLASHPACK_PARALLEL_READ", "1")
+    parallel_storage, _ = read_flashpack_file(path, device="cuda")
+    monkeypatch.setenv("FLASHPACK_PARALLEL_READ", "0")
+    legacy_storage, _ = read_flashpack_file(path, device="cuda")
+
+    assert len(parallel_storage) == len(legacy_storage)
+    for parallel_block, legacy_block in zip(
+        parallel_storage.blocks, legacy_storage.blocks
+    ):
+        assert parallel_block.dtype == legacy_block.dtype
+        assert torch.equal(
+            parallel_block.view(torch.uint8), legacy_block.view(torch.uint8)
+        )

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,204 @@
+"""Unit tests for pack_to_file: file format, alignment, dtype handling, and
+atomic-write behavior."""
+
+import os
+
+import pytest
+import torch
+from flashpack.constants import (
+    DEFAULT_ALIGN_BYTES,
+    FILE_FORMAT_V3,
+    FILE_FORMAT_V4,
+    MAGIC,
+)
+from flashpack.deserialization import (
+    get_flashpack_file_metadata,
+    revert_from_file,
+)
+from flashpack.serialization import pack_to_file
+
+
+def _random_state_dict() -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(0)
+    return {
+        "large.weight": torch.randn(64, 32, generator=generator),
+        "small.weight": torch.randn(8, generator=generator),
+        "tiny.bias": torch.randn(3, generator=generator),
+    }
+
+
+def test_pack_writes_magic_trailer(tmp_path) -> None:
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(_random_state_dict(), path, target_dtype=None)
+    with open(path, "rb") as f:
+        f.seek(-len(MAGIC), os.SEEK_END)
+        assert f.read() == MAGIC
+
+
+def test_single_dtype_produces_v3(tmp_path) -> None:
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(_random_state_dict(), path, target_dtype=None)
+    meta = get_flashpack_file_metadata(path)
+    assert meta["format"] == FILE_FORMAT_V3
+    assert meta["target_dtype"] == "float32"
+    assert meta["align_bytes"] == DEFAULT_ALIGN_BYTES
+
+
+def test_multiple_dtypes_produce_v4_macroblocks(tmp_path) -> None:
+    state_dict = {
+        "a": torch.randn(16),
+        "b": torch.randn(16).to(torch.bfloat16),
+        "c": torch.arange(16, dtype=torch.int32),
+    }
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(state_dict, path, target_dtype=None)
+    meta = get_flashpack_file_metadata(path)
+    assert meta["format"] == FILE_FORMAT_V4
+    assert len(meta["macroblocks"]) == 3
+    dtypes = {block["dtype"] for block in meta["macroblocks"]}
+    assert dtypes == {"float32", "bfloat16", "int32"}
+    # Macroblocks must not overlap and stay within the payload.
+    blocks = sorted(meta["macroblocks"], key=lambda b: b["offset_bytes"])
+    cursor = 0
+    for block in blocks:
+        assert block["offset_bytes"] >= cursor
+        cursor = block["offset_bytes"] + block["length_bytes"]
+    assert cursor == meta["total_payload_bytes"]
+
+
+def test_target_dtype_converts_all_tensors(tmp_path) -> None:
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(_random_state_dict(), path, target_dtype=torch.bfloat16)
+    meta = get_flashpack_file_metadata(path)
+    assert meta["format"] == FILE_FORMAT_V3
+    assert meta["target_dtype"] == "bfloat16"
+    state_dict = revert_from_file(path)
+    assert all(t.dtype is torch.bfloat16 for t in state_dict.values())
+
+
+def test_index_offsets_respect_alignment(tmp_path) -> None:
+    align_bytes = 64
+    state_dict = {"a": torch.randn(5), "b": torch.randn(7), "c": torch.randn(11)}
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(state_dict, path, target_dtype=None, align_bytes=align_bytes)
+    meta = get_flashpack_file_metadata(path)
+    align_elems = align_bytes // torch.tensor([], dtype=torch.float32).element_size()
+    for rec in meta["index"]:
+        assert rec["offset"] % align_elems == 0
+
+
+def test_zero_align_bytes_packs_densely(tmp_path) -> None:
+    state_dict = {"a": torch.randn(5), "b": torch.randn(7)}
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(state_dict, path, target_dtype=None, align_bytes=0)
+    meta = get_flashpack_file_metadata(path)
+    index = sorted(meta["index"], key=lambda r: r["offset"])
+    cursor = 0
+    for rec in index:
+        assert rec["offset"] == cursor
+        cursor += rec["length"]
+    assert meta["total_elems"] == 12
+
+
+def test_default_order_is_largest_first(tmp_path) -> None:
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(_random_state_dict(), path, target_dtype=None)
+    meta = get_flashpack_file_metadata(path)
+    lengths = [rec["length"] for rec in meta["index"]]
+    assert lengths == sorted(lengths, reverse=True)
+
+
+def test_name_order_selects_and_orders_tensors(tmp_path) -> None:
+    path = str(tmp_path / "pack.flashpack")
+    # Unknown names are dropped silently; listed names keep their order.
+    pack_to_file(
+        _random_state_dict(),
+        path,
+        target_dtype=None,
+        name_order=["tiny.bias", "large.weight", "not.a.tensor"],
+    )
+    meta = get_flashpack_file_metadata(path)
+    assert [rec["name"] for rec in meta["index"]] == ["tiny.bias", "large.weight"]
+
+
+def test_module_input_uses_state_dict(tmp_path) -> None:
+    model = torch.nn.Linear(4, 4)
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file(model, path, target_dtype=None)
+    state_dict = revert_from_file(path)
+    assert set(state_dict) == {"weight", "bias"}
+    assert torch.equal(state_dict["weight"], model.weight.detach())
+
+
+def test_empty_state_dict_rejected(tmp_path) -> None:
+    with pytest.raises(ValueError, match="No tensors to pack"):
+        pack_to_file({}, str(tmp_path / "pack.flashpack"), target_dtype=None)
+
+
+def test_name_order_without_matches_rejected(tmp_path) -> None:
+    with pytest.raises(ValueError, match="No tensors to pack"):
+        pack_to_file(
+            {"a": torch.randn(2)},
+            str(tmp_path / "pack.flashpack"),
+            target_dtype=None,
+            name_order=["missing"],
+        )
+
+
+def test_negative_align_bytes_rejected(tmp_path) -> None:
+    with pytest.raises(ValueError, match="align_bytes must be >= 0"):
+        pack_to_file(
+            {"a": torch.randn(2)},
+            str(tmp_path / "pack.flashpack"),
+            target_dtype=None,
+            align_bytes=-1,
+        )
+
+
+def test_non_dtype_target_rejected(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Unsupported dtype"):
+        pack_to_file(
+            {"a": torch.randn(2)},
+            str(tmp_path / "pack.flashpack"),
+            target_dtype="float32",  # type: ignore[arg-type]
+        )
+
+
+def test_overwrites_existing_destination(tmp_path) -> None:
+    path = str(tmp_path / "pack.flashpack")
+    pack_to_file({"a": torch.zeros(4)}, path, target_dtype=None)
+    pack_to_file({"b": torch.ones(8)}, path, target_dtype=None)
+    state_dict = revert_from_file(path)
+    assert set(state_dict) == {"b"}
+    assert torch.equal(state_dict["b"], torch.ones(8))
+
+
+def test_no_temp_files_left_after_success(tmp_path) -> None:
+    pack_to_file(
+        _random_state_dict(), str(tmp_path / "pack.flashpack"), target_dtype=None
+    )
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".packtmp_")]
+    assert leftovers == []
+
+
+def test_no_temp_files_left_after_failure(tmp_path, monkeypatch) -> None:
+    """A failure after the temp file is created must clean it up and leave the
+    destination untouched."""
+    import flashpack.serialization as serialization
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated memmap failure")
+
+    monkeypatch.setattr(serialization.np, "memmap", boom)
+    path = tmp_path / "pack.flashpack"
+    with pytest.raises(OSError, match="simulated memmap failure"):
+        pack_to_file({"a": torch.randn(4)}, str(path), target_dtype=None)
+    assert not path.exists()
+    leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".packtmp_")]
+    assert leftovers == []
+
+
+def test_creates_missing_destination_directory(tmp_path) -> None:
+    path = tmp_path / "nested" / "dirs" / "pack.flashpack"
+    pack_to_file({"a": torch.randn(4)}, str(path), target_dtype=None)
+    assert path.exists()

--- a/tests/test_speed_comparison.py
+++ b/tests/test_speed_comparison.py
@@ -1,16 +1,24 @@
 import os
 import time
 
-import matplotlib
-import safetensors.torch
-import torch
+import pytest
+
+pytest.importorskip("matplotlib")
+pytest.importorskip("transformers")
+
+import matplotlib  # noqa: E402
+import safetensors.torch  # noqa: E402
+import torch  # noqa: E402
 
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-import numpy as np
-from flashpack import assign_from_file, pack_to_file
-from huggingface_hub import snapshot_download
-from transformers import GPT2Model
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from flashpack import assign_from_file, pack_to_file  # noqa: E402
+from huggingface_hub import snapshot_download  # noqa: E402
+from transformers import GPT2Model  # noqa: E402
+
+# Downloads GPT-2 from the Hub and loads it onto a CUDA device.
+pytestmark = [pytest.mark.gpu, pytest.mark.network]
 
 
 def test_speed_comparison() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,168 @@
+"""Unit tests for flashpack.utils helpers."""
+
+import numpy as np
+import pytest
+import torch
+from flashpack.utils import (
+    dtype_to_string,
+    filter_state_dict,
+    get_module_and_attribute,
+    get_packing_dtype,
+    human_duration,
+    human_num_elements,
+    is_ignored_tensor_name,
+    string_to_dtype,
+    torch_dtype_to_numpy_dtype,
+)
+
+
+class TestDtypeStrings:
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            torch.float32,
+            torch.float16,
+            torch.bfloat16,
+            torch.int8,
+            torch.uint8,
+            torch.int64,
+            torch.bool,
+            torch.complex64,
+            torch.float8_e4m3fn,
+        ],
+    )
+    def test_roundtrip(self, dtype: torch.dtype) -> None:
+        assert string_to_dtype(dtype_to_string(dtype)) is dtype
+
+    def test_dtype_to_string_values(self) -> None:
+        assert dtype_to_string(torch.float32) == "float32"
+        assert dtype_to_string(torch.bfloat16) == "bfloat16"
+
+    def test_dtype_to_string_rejects_non_dtype(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            dtype_to_string("float32")  # type: ignore[arg-type]
+
+    def test_string_to_dtype_rejects_unknown_name(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported dtype string"):
+            string_to_dtype("not_a_dtype")
+
+    def test_string_to_dtype_rejects_non_dtype_torch_attribute(self) -> None:
+        # ``torch.Tensor`` exists but is not a dtype; it must not slip through.
+        with pytest.raises(ValueError, match="Unsupported dtype string"):
+            string_to_dtype("Tensor")
+
+
+class TestPackingDtype:
+    def test_fp8_packs_as_uint8(self) -> None:
+        assert get_packing_dtype(torch.float8_e4m3fn) is torch.uint8
+        assert get_packing_dtype(torch.float8_e5m2) is torch.uint8
+
+    def test_bfloat16_packs_as_uint16(self) -> None:
+        assert get_packing_dtype(torch.bfloat16) is torch.uint16
+
+    def test_complex32_packs_as_uint32(self) -> None:
+        assert get_packing_dtype(torch.complex32) is torch.uint32
+
+    @pytest.mark.parametrize(
+        "dtype", [torch.float32, torch.float16, torch.int8, torch.int64, torch.bool]
+    )
+    def test_native_dtypes_pack_as_themselves(self, dtype: torch.dtype) -> None:
+        assert get_packing_dtype(dtype) is dtype
+
+    def test_float4_rejected(self) -> None:
+        float4 = getattr(torch, "float4_e2m1fn", None)
+        if float4 is None:
+            pytest.skip("this torch build has no float4_e2m1fn")
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            get_packing_dtype(float4)
+
+
+class TestTorchToNumpyDtype:
+    def test_direct_mappings(self) -> None:
+        assert torch_dtype_to_numpy_dtype(torch.float32) is np.float32
+        assert torch_dtype_to_numpy_dtype(torch.int64) is np.int64
+        assert torch_dtype_to_numpy_dtype(torch.bool) is np.bool_
+
+    def test_bit_reinterpreted_mappings(self) -> None:
+        assert torch_dtype_to_numpy_dtype(torch.bfloat16) is np.uint16
+        assert torch_dtype_to_numpy_dtype(torch.complex32) is np.uint32
+        assert torch_dtype_to_numpy_dtype(torch.float8_e4m3fn) is np.uint8
+
+    def test_unsupported_dtype_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported dtype"):
+            torch_dtype_to_numpy_dtype(torch.qint8)
+
+
+class TestHumanReadable:
+    @pytest.mark.parametrize(
+        ("seconds", "expected"),
+        [
+            (5e-7, "500.00ns"),
+            (5e-4, "500.00µs"),
+            (0.5, "500.00ms"),
+            (5.0, "5.00s"),
+            (65.0, "1m5s"),
+            (3665.0, "1h1m5s"),
+        ],
+    )
+    def test_human_duration(self, seconds: float, expected: str) -> None:
+        assert human_duration(seconds) == expected
+
+    @pytest.mark.parametrize(
+        ("elements", "expected"),
+        [
+            (5, "5"),
+            (5_000, "5.00K"),
+            (5_000_000, "5.00M"),
+            (5_000_000_000, "5.00B"),
+        ],
+    )
+    def test_human_num_elements(self, elements: int, expected: str) -> None:
+        assert human_num_elements(elements) == expected
+
+
+class TestIgnoreFilters:
+    def test_no_filters_ignores_nothing(self) -> None:
+        assert is_ignored_tensor_name("layer.weight") is False
+
+    def test_ignore_by_name(self) -> None:
+        assert is_ignored_tensor_name("a.b", ignore_names=["a.b"]) is True
+        assert is_ignored_tensor_name("a.c", ignore_names=["a.b"]) is False
+
+    def test_ignore_by_prefix(self) -> None:
+        assert is_ignored_tensor_name("rope.freqs", ignore_prefixes=["rope"]) is True
+        assert is_ignored_tensor_name("attn.rope", ignore_prefixes=["rope"]) is False
+
+    def test_ignore_by_suffix(self) -> None:
+        assert is_ignored_tensor_name("a.bias", ignore_suffixes=[".bias"]) is True
+        assert is_ignored_tensor_name("a.weight", ignore_suffixes=[".bias"]) is False
+
+    def test_filter_state_dict(self) -> None:
+        state_dict = {
+            "keep.weight": torch.zeros(1),
+            "rope.freqs": torch.zeros(1),
+            "drop.bias": torch.zeros(1),
+        }
+        filtered = filter_state_dict(
+            state_dict, ignore_prefixes=["rope"], ignore_suffixes=[".bias"]
+        )
+        assert list(filtered) == ["keep.weight"]
+
+
+class TestGetModuleAndAttribute:
+    def test_nested_parameter(self) -> None:
+        model = torch.nn.Sequential(torch.nn.Linear(2, 2))
+        module, attr = get_module_and_attribute(model, "0.weight")
+        assert module is model[0]
+        assert attr == "weight"
+
+    def test_top_level_attribute(self) -> None:
+        model = torch.nn.Linear(2, 2)
+        module, attr = get_module_and_attribute(model, "weight")
+        assert module is model
+        assert attr == "weight"
+
+    def test_missing_module_raises(self) -> None:
+        model = torch.nn.Linear(2, 2)
+        with pytest.raises(AttributeError):
+            get_module_and_attribute(model, "does.not.exist")

--- a/tests/test_wan_pipeline.py
+++ b/tests/test_wan_pipeline.py
@@ -2,18 +2,27 @@ import os
 from typing import Optional
 
 import pytest
-import torch
-from diffusers.models import AutoencoderKLWan, WanTransformer3DModel
-from diffusers.pipelines import WanPipeline
-from diffusers.schedulers import UniPCMultistepScheduler
-from flashpack.integrations.diffusers import (
+
+pytest.importorskip("diffusers")
+pytest.importorskip("transformers")
+
+import torch  # noqa: E402
+from diffusers.models import AutoencoderKLWan, WanTransformer3DModel  # noqa: E402
+from diffusers.pipelines import WanPipeline  # noqa: E402
+from diffusers.schedulers import UniPCMultistepScheduler  # noqa: E402
+from flashpack.integrations.diffusers import (  # noqa: E402
     FlashPackDiffusersModelMixin,
     FlashPackDiffusionPipeline,
 )
-from flashpack.integrations.transformers import FlashPackTransformersModelMixin
-from flashpack.utils import timer
-from huggingface_hub import snapshot_download
-from transformers import AutoTokenizer, UMT5EncoderModel
+from flashpack.integrations.transformers import (  # noqa: E402
+    FlashPackTransformersModelMixin,
+)
+from flashpack.utils import timer  # noqa: E402
+from huggingface_hub import snapshot_download  # noqa: E402
+from transformers import AutoTokenizer, UMT5EncoderModel  # noqa: E402
+
+# Downloads the Wan 2.1 pipeline from the Hub and runs video inference.
+pytestmark = [pytest.mark.gpu, pytest.mark.network]
 
 
 class FlashPackWanTransformer3DModel(


### PR DESCRIPTION
## Summary

Adds a hermetic CPU test suite (202 tests) that now runs in CI on every push/PR via a new **Tests** workflow, and organizes the existing heavy tests behind markers so they remain runnable on suitable hosts.

### Test tiers

| Tier | Marker | Where it runs |
|------|--------|---------------|
| Unit tests (hermetic, CPU-only) | *(none)* | CI: ubuntu py3.10/3.11/3.12 + windows py3.12, CPU-only torch |
| CUDA tests | `gpu` | GPU hosts (auto-skipped when CUDA is unavailable) |
| Hub-download tests (Wan, SD1.5 VAE, CLIP, GPT-2) | `network` | Manual, on hosts with the bandwidth/disk for it |

The Windows job specifically guards the `pack_to_file` Windows behavior fixed in #17.

### New coverage (informed by recent PRs)

- **`parallel_read` integrity harness** (#24/#25): runs the *real* reader threads on CPU — only the CUDA stream/event plumbing and the pinned pool are faked — against sentinel-padded, position-dependent payloads, requiring **byte-identical** results across unaligned multi-block layouts, thread×chunk matrices, partial reads, and O_DIRECT fallback paths. Error paths must raise, never return partially-filled storage. A 50-seed fuzz covers `_plan_chunks` coverage/alignment invariants, and a `gpu`-marked test asserts parallel-vs-legacy bit-equivalence on real CUDA hosts.
- **serialization**: v3/v4 format selection (#16), alignment invariants, `name_order`, atomic-write cleanup on failure, error paths.
- **deserialization**: footer corruption handling (truncated/bad-magic/corrupt-length/unknown-format), index validation (invalid macroblock, misaligned offsets), `assign_from_file` strict/ignore semantics, dtype coercion (#15), flash-ref retention (#21).
- **mixin**: loose-kwargs filtering (#14), `flashpack_init_method`, class-level ignore/coerce flags, strict-by-default missing-param errors.
- **commands + CLI**: convert/revert roundtrips through safetensors and torch files, `metadata` output (plain/JSON/index/v4 macroblocks), error exit codes.

### Mutation-tested

To confirm the integrity harness has teeth, three corruption bugs were injected into `parallel_read.py` one at a time; each was caught:

| Injected bug | Failures |
|---|---|
| wrong head alignment in `_plan_chunks` | 50 |
| buffered read resuming at the wrong file offset | 2 |
| chunk written to the wrong destination offset | 11 |

## Test plan

- [x] `pytest -m "not gpu and not network"` — 202 passed, 3 skipped locally (macOS, CPU-only, minimal deps)
- [x] `ruff check` / `ruff check --select I` / `ruff format --check` at the pre-commit pinned version (0.3.4) — clean
- [x] Full collection succeeds in a minimal env (heavy modules self-skip via `importorskip`)
- [ ] Tests workflow green on this PR (ubuntu ×3 + windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
