### PR TITLE
test: document + script per-file isolation for the gpu/network tiers

### DIFF
--- a/scripts/run_gpu_network_tests.sh
+++ b/scripts/run_gpu_network_tests.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run the manual `gpu`/`network` test tiers on a CUDA host, the way they are
+# isolation-safe: the hermetic + gpu tests in one process, then ONE PYTEST
+# PROCESS PER NETWORK TEST FILE.
+#
+# Why per-file: patch_diffusers_auto_model() / patch_transformers_auto_model()
+# swap module globals (diffusers.models.auto_model.AutoModel, the
+# pipeline_loading_utils class resolvers) and _BaseAutoModelClass loaders with
+# no way to undo, and diffusers' lazy modules cache whatever they resolve
+# first. Composing the network files in a single process therefore produces
+# order-dependent failures — e.g. running test_integrations.py before
+# test_wan_pipeline.py fails the Wan accelerate-load test with
+# "'FlashPackWanPipeline' object has no attribute '_execution_device'" —
+# while every file passes in its own process.
+#
+# Usage (from the repo root, in an env with the CUDA + network deps):
+#   scripts/run_gpu_network_tests.sh [extra pytest args]
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+python -m pytest tests/ -m "not network" -q "$@"
+
+for f in tests/test_baseline.py tests/test_integrations.py \
+         tests/test_speed_comparison.py tests/test_wan_pipeline.py; do
+    python -m pytest "$f" -m network -q "$@"
+done

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,14 @@ Markers split the suite into tiers:
   unavailable.
 * ``network`` -- downloads model weights from the Hugging Face Hub; excluded
   from CI, run manually on a suitable host.
+
+IMPORTANT: run each ``network`` test FILE in its own pytest process
+(``scripts/run_gpu_network_tests.sh`` does this). The integration tests call
+``patch_diffusers_auto_model()`` / ``patch_transformers_auto_model()``, which
+irreversibly swap module globals and class attributes; composed single-process
+runs of the network files produce order-dependent failures (e.g. the Wan
+accelerate-load test fails with "'FlashPackWanPipeline' object has no
+attribute '_execution_device'" when test_integrations ran first).
 """
 
 import pytest


### PR DESCRIPTION
## Problem

The manual `gpu`/`network` test tiers are not single-process composable. `patch_diffusers_auto_model()` / `patch_transformers_auto_model()` swap module globals (`diffusers.models.auto_model.AutoModel`, the `pipeline_loading_utils` class resolvers) and `_BaseAutoModelClass` loaders with no undo, and diffusers' lazy modules cache whatever they resolve first. Composing the network files in one pytest process gives **order-dependent failures**:

- `pytest tests/ -m network` (all files, one process) → `test_wan_pipeline.py::test_load_and_inference_accelerate` fails with `AttributeError: 'FlashPackWanPipeline' object has no attribute '_execution_device'` — its components resolve through the patched `get_class_obj_and_candidates` left behind by `test_integrations.py`.
- Every network file **passes in its own process** on the same host/env.
- A snapshot/restore fixture around the integration tests was tried first and just moved the failure to a different test (`test_integrations.py::test_transformers` started failing in some compositions), so the entanglement runs deeper than the three obviously-patched attributes.

## Change

- `scripts/run_gpu_network_tests.sh` — runs the hermetic+gpu tests in one process, then **one pytest process per network file**. Test-tooling only; no library behavior change.
- `tests/conftest.py` — records the per-file constraint and the failure signature so the next person doesn't rediscover it.

## Validation

H100 fal runner, fleet-representative stack (torch 2.8.0, transformers 4.57.3, diffusers 0.36.0, huggingface-hub 0.36.2), flashpack@main source checkout:

| Run | Result |
|-----|--------|
| `pytest tests/ -m "not network" -q` | 203 passed, 1 skipped (test_utils' own `float4_e2m1fn` guard on torch 2.8) |
| `pytest tests/test_baseline.py -m network -q` | 2 passed |
| `pytest tests/test_integrations.py -m network -q` | 2 passed |
| `pytest tests/test_speed_comparison.py -m network -q` | 1 passed |
| `pytest tests/test_wan_pipeline.py -m network -q` | 3 passed |

(Also noticed while validating, not addressed here: on transformers 5.x the auto-factory patch never takes effect because 5.x shadows `from_pretrained` on each Auto class, so `test_transformers` fails against latest transformers; and `huggingface_hub` 1.x Xet downloads 404 on `xet-read-token` from fal runners. Both avoided by pinning the stack above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
