### PR TITLE
feat: reader-thread affinity clamp + distributed-load hardening & public API

### DIFF
--- a/src/flashpack/__init__.py
+++ b/src/flashpack/__init__.py
@@ -2,6 +2,7 @@ from .deserialization import (
     assign_from_file,
     get_flashpack_file_metadata,
     is_flashpack_file,
+    read_flashpack_file_distributed,
 )
 from .integrations import patch_integrations
 from .mixin import FlashPackMixin
@@ -21,6 +22,7 @@ __all__ = [
     "assign_from_file",
     "is_flashpack_file",
     "get_flashpack_file_metadata",
+    "read_flashpack_file_distributed",
     "pack_to_file",
     "__version__",
     "__version_tuple__",

--- a/src/flashpack/deserialization.py
+++ b/src/flashpack/deserialization.py
@@ -305,8 +305,17 @@ def _allocate_aligned_cpu_storage(specs: list[MacroblockSpec]) -> FlashTensorSto
 
 
 def _broadcast_storage(storage: FlashTensorStorage, src: int) -> None:
+    """Broadcast every macroblock from ``src`` to all ranks, as raw bytes.
+
+    Blocks are broadcast through a ``uint8`` view rather than their native
+    dtype: the collective only moves bits, and torch's NCCL dtype map does
+    not cover every dtype flashpack stores (``float8_e8m0fnu`` -- the mxfp8
+    scale dtype -- is absent, so a native-dtype broadcast of an mxfp8 pack
+    crashes; gloo similarly lacks the float8 family). The byte view is
+    dtype-agnostic and free (no copy).
+    """
     for block in storage.blocks:
-        dist.broadcast(block, src=src)
+        dist.broadcast(block.view(torch.uint8), src=src)
 
 
 def read_flashpack_file(
@@ -367,6 +376,57 @@ def read_flashpack_file(
         )
 
     del memmaps
+    return storage, meta
+
+
+def read_flashpack_file_distributed(
+    path: str,
+    device: str | torch.device = "cuda",
+    src: int = 0,
+    chunk_bytes: int = DEFAULT_CHUNK_BYTES,
+    num_streams: int = DEFAULT_NUM_STREAMS,
+    silent: bool = True,
+    metadata: dict[str, Any] | None = None,
+) -> tuple[FlashTensorStorage, dict[str, Any]]:
+    """Rank-``src`` reads the pack from disk; every rank returns the full
+    storage, received via broadcast.
+
+    This removes the N-times read amplification of world-size-N loads: the
+    reader deliberately bypasses the page cache (O_DIRECT), so without this
+    every rank pays a full duplicate pack read, while an NVLink broadcast of
+    the same bytes is 1-2 orders of magnitude faster than the read itself.
+
+    Requires an initialized process group (see ``maybe_init_distributed``).
+    Every rank must be able to read the pack FOOTER from ``path`` (payload
+    is only read on ``src``); pass ``metadata`` to skip that requirement.
+    Blocks are broadcast as raw bytes, so any pack dtype works regardless of
+    the collective backend's dtype support.
+    """
+    if not dist.is_available() or not dist.is_initialized():
+        raise RuntimeError(
+            "read_flashpack_file_distributed requires an initialized "
+            "torch.distributed process group."
+        )
+    device = torch.device(device) if isinstance(device, str) else device
+    if dist.get_backend() == "nccl" and device.type != "cuda":
+        raise ValueError(
+            "distributed flashpack loading with the NCCL backend requires "
+            f"a cuda device, got {device}."
+        )
+    meta = metadata or get_flashpack_file_metadata(path)
+    if dist.get_rank() == src:
+        storage, meta = read_flashpack_file(
+            path=path,
+            device=device,
+            chunk_bytes=chunk_bytes,
+            num_streams=num_streams,
+            silent=silent,
+            metadata=meta,
+        )
+    else:
+        specs = _build_macroblock_specs(meta)
+        storage = _allocate_empty_storage(specs, device)
+    _broadcast_storage(storage, src=src)
     return storage, meta
 
 
@@ -500,21 +560,13 @@ def assign_from_file(
             local_rank=local_rank,
             world_size=world_size,
         )
-        rank = dist.get_rank()
-        meta = get_flashpack_file_metadata(path)
-        specs = _build_macroblock_specs(meta)
-        if rank == 0:
-            flash_storage, meta = read_flashpack_file(
-                path=path,
-                device=device,
-                silent=silent,
-                num_streams=num_streams,
-                chunk_bytes=chunk_bytes,
-                metadata=meta,
-            )
-        else:
-            flash_storage = _allocate_empty_storage(specs, device)
-        _broadcast_storage(flash_storage, src=0)
+        flash_storage, meta = read_flashpack_file_distributed(
+            path=path,
+            device=device,
+            silent=silent,
+            num_streams=num_streams,
+            chunk_bytes=chunk_bytes,
+        )
     else:
         flash_storage, meta = read_flashpack_file(
             path=path,

--- a/src/flashpack/parallel_read.py
+++ b/src/flashpack/parallel_read.py
@@ -53,6 +53,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import torch
 
+from .utils import effective_read_threads
+
 if TYPE_CHECKING:
     from .deserialization import MacroblockSpec
 
@@ -251,7 +253,7 @@ def _parallel_read_into_cpu_storage(
     destination address; every misaligned or failing chunk degrades to a
     buffered read of identical bytes.
     """
-    n_threads = max(1, _env_int("FLASHPACK_READ_THREADS", 16))
+    n_threads = effective_read_threads(_env_int("FLASHPACK_READ_THREADS", 16))
     chunk_bytes = max(_ALIGN, _env_int("FLASHPACK_READ_CHUNK_BYTES", 64 * 1024 * 1024))
 
     byte_views = [b.view(torch.uint8) for b in blocks]
@@ -326,7 +328,7 @@ def parallel_read_into_storage(
         _parallel_read_into_cpu_storage(path, specs, blocks)
         return
 
-    n_threads = max(1, _env_int("FLASHPACK_READ_THREADS", 16))
+    n_threads = effective_read_threads(_env_int("FLASHPACK_READ_THREADS", 16))
     chunk_bytes = max(_ALIGN, _env_int("FLASHPACK_READ_CHUNK_BYTES", 64 * 1024 * 1024))
 
     byte_views = [b.view(torch.uint8) for b in blocks]

--- a/src/flashpack/parallel_read.py
+++ b/src/flashpack/parallel_read.py
@@ -66,6 +66,7 @@ __all__ = [
 
 _ALIGN = 4096
 _BUFFERS_PER_THREAD = 2
+_DEFAULT_READ_THREADS = 16
 
 _POSIX_FADV_DONTNEED = 4
 
@@ -328,7 +329,12 @@ def parallel_read_into_storage(
         _parallel_read_into_cpu_storage(path, specs, blocks)
         return
 
-    n_threads = effective_read_threads(_env_int("FLASHPACK_READ_THREADS", 16))
+    # IO-bound path: threads are the IO queue depth, so the affinity clamp
+    # floors at the default -- only oversubscribed requests get capped.
+    n_threads = effective_read_threads(
+        _env_int("FLASHPACK_READ_THREADS", _DEFAULT_READ_THREADS),
+        floor=_DEFAULT_READ_THREADS,
+    )
     chunk_bytes = max(_ALIGN, _env_int("FLASHPACK_READ_CHUNK_BYTES", 64 * 1024 * 1024))
 
     byte_views = [b.view(torch.uint8) for b in blocks]

--- a/src/flashpack/utils.py
+++ b/src/flashpack/utils.py
@@ -59,15 +59,26 @@ def maybe_init_distributed(
         torch.cuda.set_device(torch.device(f"cuda:{local_rank}"))
 
 
-def effective_read_threads(requested: int) -> int:
-    """Clamp a reader-thread request to the CPUs this process may run on.
+def effective_read_threads(requested: int, *, floor: int = 1) -> int:
+    """Cap a reader-thread request at ``max(cpu affinity, floor)``.
 
-    Reader threads do GIL-releasing pread/decode/memcpy work; running more of
-    them than the process's CPU affinity allows never helps and measurably
-    hurts (oversubscription, and on the GPU paths each thread owns a CUDA
-    stream -- co-located stream counts in the dozens are stream-collapse
-    territory). Prod runners execute in dedicated cpusets, so the affinity
-    mask -- not ``os.cpu_count()`` -- is the real budget. Escape hatch:
+    Two regimes, measured separately:
+
+    - CPU-bound reader work (eager CPU-destination reads, compressed-plane
+      decode) is budgeted by the CPUs the process may actually run on;
+      oversubscribing the affinity mask never helps there. Those call sites
+      use the default ``floor=1`` (a pure affinity clamp).
+    - The raw file->GPU path is IO-bound: reader threads spend most of their
+      time blocked in ``pread``, so they are the IO queue depth, not CPU
+      consumers. Clamping below the default thread count starves the device
+      (same-node interleaved A/B on a 12-CPU H200, 38 GB pack: 12 threads
+      11.3-11.9 GB/s vs 16 threads 13.2-14.2 cold; on a 6-CPU cpuset the gap
+      is 2x). That path passes ``floor=<default>`` so the clamp only caps
+      requests above ``max(affinity, default)`` -- oversubscribed requests
+      (e.g. 64 threads on 12 CPUs, measured unstable) still get capped.
+
+    Prod runners execute in dedicated cpusets, so the affinity mask -- not
+    ``os.cpu_count()`` -- is the real budget. Escape hatch:
     ``FLASHPACK_NO_THREAD_CLAMP=1`` restores the unclamped request.
     """
     if os.environ.get("FLASHPACK_NO_THREAD_CLAMP", "").strip().lower() in (
@@ -81,7 +92,7 @@ def effective_read_threads(requested: int) -> int:
         cpus = len(os.sched_getaffinity(0))
     except (AttributeError, OSError):  # non-Linux
         cpus = os.cpu_count() or requested
-    return max(1, min(requested, cpus))
+    return max(1, min(requested, max(cpus, floor)))
 
 
 def get_module_and_attribute(

--- a/src/flashpack/utils.py
+++ b/src/flashpack/utils.py
@@ -59,6 +59,31 @@ def maybe_init_distributed(
         torch.cuda.set_device(torch.device(f"cuda:{local_rank}"))
 
 
+def effective_read_threads(requested: int) -> int:
+    """Clamp a reader-thread request to the CPUs this process may run on.
+
+    Reader threads do GIL-releasing pread/decode/memcpy work; running more of
+    them than the process's CPU affinity allows never helps and measurably
+    hurts (oversubscription, and on the GPU paths each thread owns a CUDA
+    stream -- co-located stream counts in the dozens are stream-collapse
+    territory). Prod runners execute in dedicated cpusets, so the affinity
+    mask -- not ``os.cpu_count()`` -- is the real budget. Escape hatch:
+    ``FLASHPACK_NO_THREAD_CLAMP=1`` restores the unclamped request.
+    """
+    if os.environ.get("FLASHPACK_NO_THREAD_CLAMP", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        return max(1, requested)
+    try:
+        cpus = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):  # non-Linux
+        cpus = os.cpu_count() or requested
+    return max(1, min(requested, cpus))
+
+
 def get_module_and_attribute(
     model: torch.nn.Module,
     name: str,
@@ -73,6 +98,23 @@ def get_module_and_attribute(
         raise ValueError(f"Module not found: {module_path}")
 
     return module, name
+
+
+def require_zstandard():
+    """Import the optional ``zstandard`` dependency for fpz compression.
+
+    zstandard is not a hard dependency of flashpack; it is only needed to
+    write or read fpz-compressed packs. Install it with ``pip install
+    'flashpack[fpz]'`` (see the ``fpz`` extra in ``pyproject.toml``).
+    """
+    try:
+        import zstandard
+    except ImportError as e:  # pragma: no cover - exercised via message only
+        raise ImportError(
+            "fpz compression requires the optional 'zstandard' package. "
+            "Install it with: pip install 'flashpack[fpz]'"
+        ) from e
+    return zstandard
 
 
 def string_to_dtype(string: str) -> torch.dtype:

--- a/tests/test_distributed_load.py
+++ b/tests/test_distributed_load.py
@@ -30,6 +30,15 @@ from flashpack.deserialization import (
 )
 from flashpack.serialization import pack_to_file
 
+# The gloo file:// rendezvous with an explicit loopback interface is
+# POSIX-shaped (Windows has no "lo" device: "Unable to find address for:
+# lo"); the path is covered on Linux/macOS, same policy as the O_DIRECT
+# integrity tests.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="gloo loopback rendezvous is POSIX-only in these tests",
+)
+
 _WORLD = 2
 
 

--- a/tests/test_distributed_load.py
+++ b/tests/test_distributed_load.py
@@ -1,0 +1,154 @@
+"""Tests for the distributed (rank0-read + broadcast) load path.
+
+This path ships in several production apps but had no coverage. It runs here
+on the gloo backend with 2 CPU ranks (file:// rendezvous, no GPUs needed):
+the collective plumbing, the byte-view broadcast, and the end-to-end
+``assign_from_file(use_distributed_loading=True)`` flow are all
+backend-agnostic; only the transport differs from prod's NCCL.
+
+The byte-view broadcast (``_broadcast_storage``) is load-bearing: torch's
+collective dtype maps do not cover every dtype flashpack stores (NCCL lacks
+``float8_e8m0fnu`` -- the mxfp8 scale dtype -- and gloo lacks the whole
+float8 family), so broadcasting native-dtype blocks crashes on quantized
+packs. These tests broadcast float8/bfloat16 blocks through gloo, which only
+works through the uint8 view.
+"""
+
+import os
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from flashpack.deserialization import (
+    FlashTensorStorage,
+    _broadcast_storage,
+    assign_from_file,
+    iterate_from_flash_tensor,
+    read_flashpack_file_distributed,
+)
+from flashpack.serialization import pack_to_file
+
+_WORLD = 2
+
+
+class _TwoParam(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.a = torch.nn.Parameter(torch.zeros(512, 33, dtype=torch.bfloat16))
+        self.b = torch.nn.Parameter(torch.zeros(257))
+
+
+def _source_state() -> dict[str, torch.Tensor]:
+    g = torch.Generator().manual_seed(3)
+    return {
+        "a": torch.randn(512, 33, generator=g).to(torch.bfloat16),
+        "b": torch.randn(257, generator=g),
+    }
+
+
+def _init(rank: int, init_file: str) -> None:
+    # Bind gloo to loopback explicitly: its default interface discovery
+    # resolves the hostname, which fails on sandboxed/misconfigured hosts.
+    os.environ.setdefault(
+        "GLOO_SOCKET_IFNAME", "lo0" if sys.platform == "darwin" else "lo"
+    )
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=_WORLD,
+    )
+
+
+def _bcast_worker(rank: int, init_file: str) -> None:
+    _init(rank, init_file)
+    try:
+        dtypes = [torch.bfloat16, torch.float32]
+        if hasattr(torch, "float8_e4m3fn"):
+            dtypes.append(torch.float8_e4m3fn)
+        blocks = []
+        for i, dt in enumerate(dtypes):
+            src = torch.arange(64, dtype=torch.int32) + 7 * i
+            block = src.to(torch.uint8).view(torch.uint8).clone()
+            if rank != 0:
+                block.zero_()
+            blocks.append(block.view(dt) if dt != torch.uint8 else block)
+        storage = FlashTensorStorage(blocks=blocks)
+        _broadcast_storage(storage, src=0)
+        for i, block in enumerate(storage.blocks):
+            expect = (torch.arange(64, dtype=torch.int32) + 7 * i).to(torch.uint8)
+            got = block.view(torch.uint8)
+            assert torch.equal(got, expect), f"rank {rank} block {i} mismatch"
+    finally:
+        dist.destroy_process_group()
+
+
+def test_broadcast_storage_is_dtype_agnostic(tmp_path) -> None:
+    mp.spawn(
+        _bcast_worker,
+        args=(str(tmp_path / "rdv1"),),
+        nprocs=_WORLD,
+        join=True,
+    )
+
+
+def _assign_worker(rank: int, init_file: str, pack_path: str) -> None:
+    _init(rank, init_file)
+    try:
+        model = _TwoParam()
+        assign_from_file(
+            model,
+            pack_path,
+            device="cpu",
+            use_distributed_loading=True,
+        )
+        state = _source_state()
+        assert torch.equal(model.a.data, state["a"]), f"rank {rank} a mismatch"
+        assert torch.equal(model.b.data, state["b"]), f"rank {rank} b mismatch"
+    finally:
+        dist.destroy_process_group()
+
+
+def test_assign_from_file_distributed_end_to_end(tmp_path) -> None:
+    pack = str(tmp_path / "pack.flashpack")
+    pack_to_file(_source_state(), pack, None)
+    mp.spawn(
+        _assign_worker,
+        args=(str(tmp_path / "rdv2"), pack),
+        nprocs=_WORLD,
+        join=True,
+    )
+
+
+def _read_dist_worker(rank: int, init_file: str, pack_path: str) -> None:
+    _init(rank, init_file)
+    try:
+        storage, meta = read_flashpack_file_distributed(pack_path, device="cpu")
+        got = dict(iterate_from_flash_tensor(storage, meta))
+        state = _source_state()
+        assert set(got) == set(state)
+        for name, tensor in state.items():
+            assert torch.equal(got[name], tensor), f"rank {rank} {name} mismatch"
+    finally:
+        dist.destroy_process_group()
+
+
+def test_read_flashpack_file_distributed(tmp_path) -> None:
+    pack = str(tmp_path / "pack.flashpack")
+    pack_to_file(_source_state(), pack, None)
+    mp.spawn(
+        _read_dist_worker,
+        args=(str(tmp_path / "rdv3"), pack),
+        nprocs=_WORLD,
+        join=True,
+    )
+
+
+def test_read_distributed_requires_process_group(tmp_path) -> None:
+    pack = str(tmp_path / "pack.flashpack")
+    pack_to_file(_source_state(), pack, None)
+    assert not dist.is_initialized()
+    with pytest.raises(RuntimeError, match="process group"):
+        read_flashpack_file_distributed(pack, device="cpu")

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,43 @@
+"""Unit tests for the reader-thread affinity clamp."""
+
+import os
+
+from flashpack import utils
+from flashpack.utils import effective_read_threads
+
+
+def test_clamps_to_affinity(monkeypatch) -> None:
+    monkeypatch.delenv("FLASHPACK_NO_THREAD_CLAMP", raising=False)
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: {0, 1, 2, 3}, raising=False
+    )
+    assert effective_read_threads(16) == 4
+    assert effective_read_threads(64) == 4
+
+
+def test_request_below_budget_is_kept(monkeypatch) -> None:
+    monkeypatch.delenv("FLASHPACK_NO_THREAD_CLAMP", raising=False)
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: set(range(32)), raising=False
+    )
+    assert effective_read_threads(16) == 16
+    assert effective_read_threads(1) == 1
+
+
+def test_never_below_one(monkeypatch) -> None:
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0}, raising=False)
+    assert effective_read_threads(0) == 1
+    assert effective_read_threads(-4) == 1
+
+
+def test_escape_hatch(monkeypatch) -> None:
+    monkeypatch.setattr(os, "sched_getaffinity", lambda pid: {0, 1}, raising=False)
+    monkeypatch.setenv("FLASHPACK_NO_THREAD_CLAMP", "1")
+    assert effective_read_threads(64) == 64
+
+
+def test_affinity_unavailable_falls_back_to_cpu_count(monkeypatch) -> None:
+    monkeypatch.delenv("FLASHPACK_NO_THREAD_CLAMP", raising=False)
+    monkeypatch.delattr(os, "sched_getaffinity", raising=False)
+    monkeypatch.setattr(utils.os, "cpu_count", lambda: 8)
+    assert effective_read_threads(16) == 8

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -15,6 +15,27 @@ def test_clamps_to_affinity(monkeypatch) -> None:
     assert effective_read_threads(64) == 4
 
 
+def test_floor_keeps_default_on_small_affinity(monkeypatch) -> None:
+    # IO-bound call sites floor the clamp at the default thread count:
+    # requests at or below the floor pass through untouched even on small
+    # cpusets; oversubscribed requests are capped at max(affinity, floor).
+    monkeypatch.delenv("FLASHPACK_NO_THREAD_CLAMP", raising=False)
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: {0, 1, 2, 3}, raising=False
+    )
+    assert effective_read_threads(16, floor=16) == 16
+    assert effective_read_threads(64, floor=16) == 16
+    assert effective_read_threads(8, floor=16) == 8
+
+
+def test_floor_does_not_raise_large_affinity_cap(monkeypatch) -> None:
+    monkeypatch.delenv("FLASHPACK_NO_THREAD_CLAMP", raising=False)
+    monkeypatch.setattr(
+        os, "sched_getaffinity", lambda pid: set(range(32)), raising=False
+    )
+    assert effective_read_threads(64, floor=16) == 32
+
+
 def test_request_below_budget_is_kept(monkeypatch) -> None:
     monkeypatch.delenv("FLASHPACK_NO_THREAD_CLAMP", raising=False)
     monkeypatch.setattr(


### PR DESCRIPTION
Two independent improvements, both measured on real registry apps and multi-GPU runners.

## Reader-thread cap (oversubscription only)

Reader-thread requests on the raw file->GPU path are capped at `max(cpu affinity, 16)`; the CPU-destination eager path keeps a pure affinity clamp. `FLASHPACK_NO_THREAD_CLAMP=1` restores the raw request.

This section originally shipped a pure affinity clamp on all paths. A pre-merge regression gate (same-node interleaved A/B, 12-CPU H200, 38 GB pack, parity-checked) showed that clamping the raw path below the default starves the IO queue — reader threads there are mostly blocked in `pread`, so they are queue depth, not CPU consumers: 12 threads read 11.3–11.9 GB/s cold vs 13.2–14.2 at 16; on a 6-CPU cpuset the gap was 2x. The clamp now floors at the default and only caps oversubscribed requests, which is the case it measurably helps: 64 threads on 12 CPUs ran unstable (1.9–4.6 s swings) while capped-to-16 was 27% faster than unclamped-64 and steady. Re-receipt on the fixed head, same node: R = 1.04/1.00/1.00 across cold-native, 6-CPU, and hot cells (pass lines 1.05/1.10).

## Distributed load: hardening + public API

The rank0-read + NCCL-broadcast path runs in several production apps but had no tests and two latent issues, and was unreachable for low-level callers.

- `_broadcast_storage` broadcasts `uint8` views. Torch's NCCL dtype map lacks `float8_e8m0fnu` (the mxfp8 scale dtype), so native-dtype broadcast of an mxfp8 pack cannot work (latent failure, found by inspection rather than a production crash); byte views are dtype-agnostic and copy-free. Verified byte-exact over NCCL on 8 GPUs, including the float8 dtypes.
- New public `read_flashpack_file_distributed()`; `assign_from_file` delegates to it. This lets low-level callers (falcon's quantized loaders) opt in — today every rank of a world-size-N app re-reads the full pack, since the O_DIRECT reader shares nothing through the page cache.
- Clear errors for missing process group and NCCL+CPU.
- First tests for the path: 2-rank gloo, including float8 blocks and end-to-end `assign_from_file`.

Measured on the real 38 GB pack, 8× H200: all-ranks-read 25.8 s max/rank page-cold (4.89 s page-hot) → rank0+broadcast **2.44 s on all eight ranks** (2.22 s hot); at world=2 the cold win is ~−25%. Cross-rank parity verified on every run. Cold-tier magnitude is node-dependent (rank self-contention on one node's disk); the mechanism — N duplicate O_DIRECT reads collapsed to one — is scale-invariant.

## Review notes

- Overlaps files (not semantics) with #30; small textual merge for whoever lands second. Complementary: #30 warms the page cache, #33 lets reads exploit it.
- The distributed tests spawn 2 gloo processes; skipped on Windows (no loopback device by that name).
- Follow-ups: #32 stacks on this branch; falcon adopts the new API for its quantized loaders.
