### PR TITLE
fix: lease pinned staging bundles per load to make concurrent loads safe

### DIFF
--- a/src/flashpack/parallel_read.py
+++ b/src/flashpack/parallel_read.py
@@ -41,6 +41,7 @@ Tunables (environment):
 - ``FLASHPACK_READ_CHUNK_BYTES``     chunk size (default 64 MiB)
 - ``FLASHPACK_DIRECT_IO=0``          never use O_DIRECT
 - ``FLASHPACK_CACHE_PINNED=0``       free pinned staging buffers after load (CUDA)
+- ``FLASHPACK_PINNED_CACHE_BUNDLES``  max cached staging bundles (default 16)
 """
 
 import ctypes
@@ -100,36 +101,67 @@ def parallel_read_supported(device: torch.device) -> bool:
     return False
 
 
-# Pinned staging memory is expensive to allocate (~0.5 s/GB), so the pool is
-# kept for the process lifetime by default: model servers load all their
-# packs back-to-back at startup and the pool (threads x 2 x chunk, 2 GiB at
-# defaults) amortizes across them. Set FLASHPACK_CACHE_PINNED=0 or call
-# release_pinned_pool() to free it.
-_PINNED_POOL: dict = {}
+# Pinned staging memory is expensive to allocate (~0.5 s/GB), so freed
+# buffer bundles are cached for the process lifetime by default: model
+# servers load all their packs back-to-back at startup and the cache
+# (threads x 2 x chunk, 2 GiB at defaults) amortizes across them. Set
+# FLASHPACK_CACHE_PINNED=0 or call release_pinned_pool() to free it.
+#
+# Buffers are LEASED per load, never shared: two concurrent
+# read_flashpack_file calls previously received the SAME buffer objects and
+# silently copied each other's bytes onto the GPU (bit-exact packs, garbage
+# weights — the flux-2 checkerboard incident). A lease checks bundles out of
+# the free list under the lock; concurrent loads that outrun the cache
+# simply allocate fresh bundles and return them on release.
+_PINNED_FREE: dict = {}  # chunk_bytes -> list of [buf x _BUFFERS_PER_THREAD]
 _PINNED_POOL_LOCK = threading.Lock()
 
 
-def _get_pinned_pool(n_threads: int, chunk_bytes: int) -> list:
-    key = (n_threads, chunk_bytes)
+def _cached_bundle_cap() -> int:
+    """Max bundles kept in the free list (per process)."""
+    return max(0, _env_int("FLASHPACK_PINNED_CACHE_BUNDLES", 16))
+
+
+def _lease_pinned_bundles(n_threads: int, chunk_bytes: int) -> list:
+    """Check out ``n_threads`` exclusive staging bundles (allocating any
+    shortfall). Bundles are keyed by chunk size only, so loads with
+    different thread counts still reuse each other's buffers."""
+    bundles: list = []
     with _PINNED_POOL_LOCK:
-        pool = _PINNED_POOL.get(key)
-        if pool is None:
-            pool = [
-                [
-                    torch.empty(chunk_bytes, dtype=torch.uint8, pin_memory=True)
-                    for _ in range(_BUFFERS_PER_THREAD)
-                ]
-                for _ in range(n_threads)
+        free = _PINNED_FREE.get(chunk_bytes)
+        while free and len(bundles) < n_threads:
+            bundles.append(free.pop())
+    while len(bundles) < n_threads:
+        bundles.append(
+            [
+                torch.empty(chunk_bytes, dtype=torch.uint8, pin_memory=True)
+                for _ in range(_BUFFERS_PER_THREAD)
             ]
-            _PINNED_POOL.clear()  # hold at most one pool
-            _PINNED_POOL[key] = pool
-        return pool
+        )
+    return bundles
+
+
+def _release_pinned_bundles(chunk_bytes: int, bundles: list) -> None:
+    """Return leased bundles to the free list, capped; extras are dropped
+    (their pinned memory is freed by refcount)."""
+    with _PINNED_POOL_LOCK:
+        # hold bundles for at most one chunk size — a size change retires
+        # the old cache instead of pinning both generations forever
+        for key in list(_PINNED_FREE):
+            if key != chunk_bytes:
+                del _PINNED_FREE[key]
+        free = _PINNED_FREE.setdefault(chunk_bytes, [])
+        cap = _cached_bundle_cap()
+        for bundle in bundles:
+            if len(free) >= cap:
+                break
+            free.append(bundle)
 
 
 def release_pinned_pool() -> None:
     """Free the cached pinned staging buffers."""
     with _PINNED_POOL_LOCK:
-        _PINNED_POOL.clear()
+        _PINNED_FREE.clear()
 
 
 def _page_cache_resident_fraction(path: str, size: int) -> float:
@@ -358,7 +390,7 @@ def parallel_read_into_storage(
         and _page_cache_resident_fraction(path, size) < 0.9
     )
 
-    pool = _get_pinned_pool(n_threads, chunk_bytes)
+    pool = _lease_pinned_bundles(n_threads, chunk_bytes)
     errors: list[BaseException] = []
 
     def _reader(thread_idx: int) -> None:
@@ -411,12 +443,19 @@ def parallel_read_into_storage(
         threading.Thread(target=_reader, args=(i,), daemon=True)
         for i in range(n_threads)
     ]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-    torch.cuda.synchronize(device)
-    if not _env_flag("FLASHPACK_CACHE_PINNED"):
-        release_pinned_pool()
+    try:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        torch.cuda.synchronize(device)
+    finally:
+        # Buffers go back to the cache only after every reader thread has
+        # exited and the device synchronized — no in-flight H2D can source
+        # from a bundle the next load might lease.
+        if _env_flag("FLASHPACK_CACHE_PINNED"):
+            _release_pinned_bundles(chunk_bytes, pool)
+        else:
+            release_pinned_pool()
     if errors:
         raise errors[0]

--- a/tests/test_parallel_read_integrity.py
+++ b/tests/test_parallel_read_integrity.py
@@ -88,7 +88,8 @@ def cpu_parallel_read(monkeypatch):
         ]
 
     monkeypatch.setattr(parallel_read.torch, "cuda", _FakeCuda)
-    monkeypatch.setattr(parallel_read, "_get_pinned_pool", fake_pool)
+    monkeypatch.setattr(parallel_read, "_lease_pinned_bundles", fake_pool)
+    monkeypatch.setattr(parallel_read, "_release_pinned_bundles", lambda *a: None)
     monkeypatch.setenv("FLASHPACK_DIRECT_IO", "0")
     # Small defaults keep the fake staging pool tiny; tests override as needed.
     monkeypatch.setenv("FLASHPACK_READ_THREADS", "4")

--- a/tests/test_pinned_lease.py
+++ b/tests/test_pinned_lease.py
@@ -1,0 +1,91 @@
+"""Unit tests for the leased pinned staging cache: concurrent loads must
+never share buffer objects (the flux-2 checkerboard corruption class)."""
+
+import threading
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from flashpack import parallel_read as pr  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cache():
+    pr.release_pinned_pool()
+    yield
+    pr.release_pinned_pool()
+
+
+def _ids(bundles):
+    return {id(buf) for bundle in bundles for buf in bundle}
+
+
+class TestPinnedLease:
+    def test_concurrent_leases_are_disjoint(self, monkeypatch) -> None:
+        # pin_memory needs CUDA on some builds; plain empty is fine for identity tests
+        monkeypatch.setattr(
+            torch,
+            "empty",
+            lambda *a, **kw: torch.zeros(a[0], dtype=kw.get("dtype", torch.uint8)),
+        )
+        results = []
+
+        def worker():
+            results.append(pr._lease_pinned_bundles(4, 1024))
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        all_ids: set = set()
+        for bundles in results:
+            ids = _ids(bundles)
+            assert not (all_ids & ids), "two concurrent leases shared a buffer"
+            all_ids |= ids
+
+    def test_release_then_lease_reuses(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            torch,
+            "empty",
+            lambda *a, **kw: torch.zeros(a[0], dtype=kw.get("dtype", torch.uint8)),
+        )
+        a = pr._lease_pinned_bundles(3, 2048)
+        pr._release_pinned_bundles(2048, a)
+        b = pr._lease_pinned_bundles(3, 2048)
+        assert _ids(b) == _ids(a)
+
+    def test_thread_count_change_still_reuses(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            torch,
+            "empty",
+            lambda *a, **kw: torch.zeros(a[0], dtype=kw.get("dtype", torch.uint8)),
+        )
+        a = pr._lease_pinned_bundles(8, 2048)
+        pr._release_pinned_bundles(2048, a)
+        b = pr._lease_pinned_bundles(2, 2048)
+        assert _ids(b) <= _ids(a) and len(b) == 2
+
+    def test_cache_cap_enforced(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            torch,
+            "empty",
+            lambda *a, **kw: torch.zeros(a[0], dtype=kw.get("dtype", torch.uint8)),
+        )
+        monkeypatch.setenv("FLASHPACK_PINNED_CACHE_BUNDLES", "2")
+        a = pr._lease_pinned_bundles(5, 1024)
+        pr._release_pinned_bundles(1024, a)
+        assert len(pr._PINNED_FREE[1024]) == 2
+
+    def test_chunk_size_change_retires_old_cache(self, monkeypatch) -> None:
+        monkeypatch.setattr(
+            torch,
+            "empty",
+            lambda *a, **kw: torch.zeros(a[0], dtype=kw.get("dtype", torch.uint8)),
+        )
+        a = pr._lease_pinned_bundles(2, 1024)
+        pr._release_pinned_bundles(1024, a)
+        b = pr._lease_pinned_bundles(2, 4096)
+        pr._release_pinned_bundles(4096, b)
+        assert list(pr._PINNED_FREE) == [4096]


### PR DESCRIPTION
The shared pinned-buffer pool is unsafe under concurrent loads: two simultaneous `read_flashpack_file` calls in one process can receive the same staging bundles and silently corrupt each other's weights. This is why id-lora serializes request-path loads behind a lock and why the #11822/#11826 workarounds exist.

This changes the pool to a lease: each load takes exclusive pinned bundles (keyed by chunk size, capped by `FLASHPACK_PINNED_CACHE_BUNDLES`, default 16) and releases them after its reader threads join and synchronize. Single loads are unchanged; concurrent loads become safe. Note the cap bounds the free-list, not retained host memory: bundles dropped above the cap return to torch's caching host allocator, which recycles them (measured at 32 threads on a real app: the leased build was faster than its merge-base in 6/6 paired 40.86 GB reads, 3.26 s vs 3.75 s mean).

Measured on flux-2 (B200): the treated arm carried this commit plus the re-enabled 3-way concurrent component load it makes safe (concurrency without the lease is the known-broken configuration, so the two ship together). Two simultaneous same-node loads produce byte-identical outputs — including a deliberate worst-case pair racing on one node — and the concurrent load gives 13.1–15.0 s vs 16.6–18.7 s sequential (2–3 boots per arm; cache state dominates wider swings). 216 tests green including new lease units.

Note the latency win lands only when consumers re-enable concurrency — follow-ups once released: restore flux-2's parallel component load and remove id-lora's request-path lock (the id-lora one needs a pinned-alloc cost check first; per-request lease churn above the cache cap is unmeasured).
