### PR TITLE
ci(actions): pin release-workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -19,11 +19,11 @@ jobs:
     environment:
       name: create-github-release
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.9"
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -19,11 +19,11 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       name: ${{ steps.parse.outputs.name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4
         with:
           python-version: "3.10"
 
@@ -46,7 +46,7 @@ jobs:
         run: python -m build
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist
@@ -62,10 +62,10 @@ jobs:
       id-token: write
     steps:
       - name: Download dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
Routine supply-chain hygiene for the release workflows.

Third-party actions were referenced by mutable tags, which means the code that actually runs in a release can change without any corresponding change in this repo. Pinning to SHAs makes release runs reproducible and makes action upgrades explicit and reviewable.

## What changed

Each ref is pinned to the commit SHA it resolves to **today**, with the resolved version in a trailing comment:

| action | was | now |
|---|---|---|
| `actions/checkout` | `@v3` | `a37ce91…` (v3.7.0) |
| `actions/setup-python` | `@v2` | `e9aba2c…` (v2.3.4) |
| `actions/upload-artifact` | `@v4` | `ea165f8…` (v4.6.2) |
| `actions/download-artifact` | `@v4` | `d3f86a1…` (v4.3.0) |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `dc37677…` (v1.14.2) |

**No version changes** — behavior is identical to the last run of these workflows. `create-release.yaml` gets the same two pins.

## Follow-ups, deliberately not here

- `checkout@v3` and `setup-python@v2` are both past EOL. This PR pins them where they are rather than bumping, to keep the diff behavior-neutral. The version bump is worth its own PR.
- `test.yaml` and `pre-commit.yaml` still reference actions by tag (`checkout@v3/v4`, `setup-python@v3/v5`, `pre-commit/action@v3.0.0`). Left out to keep this focused on the release path; easy follow-up for consistency.

Enabling Dependabot for `github-actions` would keep these pins maintained rather than frozen.