### PR TITLE
feat(io): adapt reader concurrency for cold files

### DIFF
--- a/src/flashpack/parallel_read.py
+++ b/src/flashpack/parallel_read.py
@@ -39,6 +39,9 @@ Tunables (environment):
 - ``FLASHPACK_CPU_PARALLEL_READ=1``  enable eager parallel reads for CPU targets
 - ``FLASHPACK_READ_THREADS``         reader threads (default 16)
 - ``FLASHPACK_READ_CHUNK_BYTES``     chunk size (default 64 MiB)
+- ``FLASHPACK_CONDITIONAL_RAMP=0``   disable slow direct-read ramp
+- ``FLASHPACK_RAMP_THREADS``         ramp target (default 32)
+- ``FLASHPACK_RAMP_THRESHOLD_S``     first-read threshold (default 0.2 s)
 - ``FLASHPACK_DIRECT_IO=0``          never use O_DIRECT
 - ``FLASHPACK_CACHE_PINNED=0``       free pinned staging buffers after load (CUDA)
 """
@@ -48,6 +51,7 @@ import mmap as mmap_module
 import os
 import queue
 import threading
+import time
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -65,8 +69,11 @@ __all__ = [
 ]
 
 _ALIGN = 4096
-_BUFFERS_PER_THREAD = 2
+_BUFFERS_PER_THREAD = 1
 _DEFAULT_READ_THREADS = 16
+_DEFAULT_RAMP_THREADS = 32
+_DEFAULT_RAMP_THRESHOLD_SECONDS = 0.2
+_RAMP_DECISION_READS = 4
 
 _POSIX_FADV_DONTNEED = 4
 
@@ -74,6 +81,13 @@ _POSIX_FADV_DONTNEED = 4
 def _env_int(name: str, default: int) -> int:
     try:
         return int(os.environ.get(name, default))
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, default))
     except ValueError:
         return default
 
@@ -122,17 +136,26 @@ def parallel_read_supported(device: torch.device) -> bool:
 
 # Pinned staging memory is expensive to allocate (~0.5 s/GB), so the pool is
 # kept for the process lifetime by default: model servers load all their
-# packs back-to-back at startup and the pool (threads x 2 x chunk, 2 GiB at
-# defaults) amortizes across them. Set FLASHPACK_CACHE_PINNED=0 or call
+# packs back-to-back at startup and the initial pool (threads x chunk, 1 GiB at
+# defaults) amortizes across them. Slow large reads can grow it to 2 GiB. One
+# buffer per thread still overlaps I/O and H2D across reader threads while
+# halving the warm first-load pinning cost. Set
+# FLASHPACK_CACHE_PINNED=0 or call
 # release_pinned_pool() to free it.
 _PINNED_POOL: dict = {}
 _PINNED_POOL_LOCK = threading.Lock()
 
 
 def _get_pinned_pool(n_threads: int, chunk_bytes: int) -> list:
-    key = (n_threads, chunk_bytes)
     with _PINNED_POOL_LOCK:
-        pool = _PINNED_POOL.get(key)
+        pool = next(
+            (
+                cached
+                for (cached_threads, cached_bytes), cached in _PINNED_POOL.items()
+                if cached_bytes == chunk_bytes and cached_threads >= n_threads
+            ),
+            None,
+        )
         if pool is None:
             pool = [
                 [
@@ -142,8 +165,25 @@ def _get_pinned_pool(n_threads: int, chunk_bytes: int) -> list:
                 for _ in range(n_threads)
             ]
             _PINNED_POOL.clear()  # hold at most one pool
-            _PINNED_POOL[key] = pool
+            _PINNED_POOL[(n_threads, chunk_bytes)] = pool
         return pool
+
+
+def _grow_pinned_pool(pool: list, n_threads: int, chunk_bytes: int) -> None:
+    """Grow the active pool in place so existing readers keep their buffers."""
+    with _PINNED_POOL_LOCK:
+        if len(pool) >= n_threads:
+            return
+        extra = [
+            [
+                torch.empty(chunk_bytes, dtype=torch.uint8, pin_memory=True)
+                for _ in range(_BUFFERS_PER_THREAD)
+            ]
+            for _ in range(n_threads - len(pool))
+        ]
+        pool.extend(extra)
+        _PINNED_POOL.clear()
+        _PINNED_POOL[(n_threads, chunk_bytes)] = pool
 
 
 def release_pinned_pool() -> None:
@@ -348,7 +388,7 @@ def parallel_read_into_storage(
 
     # IO-bound path: threads are the IO queue depth, so the affinity clamp
     # floors at the default -- only oversubscribed requests get capped.
-    n_threads = effective_read_threads(
+    base_threads = effective_read_threads(
         _env_int("FLASHPACK_READ_THREADS", _DEFAULT_READ_THREADS),
         floor=_DEFAULT_READ_THREADS,
     )
@@ -369,10 +409,9 @@ def parallel_read_into_storage(
     for chunk in chunks:
         work.put(chunk)
     n_chunks = len(chunks)
+    payload_bytes = sum(chunk[3] for chunk in chunks)
 
-    n_threads = min(n_threads, max(1, n_chunks))
-    for _ in range(n_threads):
-        work.put(None)
+    base_threads = min(base_threads, max(1, n_chunks))
 
     size = os.path.getsize(path)
     use_direct = (
@@ -383,10 +422,39 @@ def parallel_read_into_storage(
         and _page_cache_resident_fraction(path, size) < 0.9
     )
 
-    pool = _get_pinned_pool(n_threads, chunk_bytes)
+    ramp_threads = effective_read_threads(
+        _env_int("FLASHPACK_RAMP_THREADS", _DEFAULT_RAMP_THREADS),
+        # Like the base floor, this is I/O queue depth rather than a CPU
+        # worker budget. Preserve the default ramp even on small cpusets.
+        floor=_DEFAULT_RAMP_THREADS,
+    )
+    max_threads = min(max(base_threads, ramp_threads), max(1, n_chunks))
+    can_ramp = (
+        use_direct
+        and _env_flag("FLASHPACK_CONDITIONAL_RAMP")
+        and max_threads > base_threads
+        # Do not allocate another pinned pool for a small tail of work. At
+        # defaults this limits the ramp to payloads of at least 4 GiB.
+        and payload_bytes >= 2 * max_threads * chunk_bytes
+    )
+    for _ in range(max_threads if can_ramp else base_threads):
+        work.put(None)
+
+    pool = _get_pinned_pool(base_threads, chunk_bytes)
     errors: list[BaseException] = []
+    completed_reads = 0
+    progress_lock = threading.Lock()
+    ramp_decision = threading.Event()
+    should_ramp = False
+    decision_reads = min(_RAMP_DECISION_READS, n_chunks)
+    ramp_threshold = max(
+        0.0,
+        _env_float("FLASHPACK_RAMP_THRESHOLD_S", _DEFAULT_RAMP_THRESHOLD_SECONDS),
+    )
+    read_started = time.perf_counter()
 
     def _reader(thread_idx: int) -> None:
+        nonlocal completed_reads, should_ramp
         try:
             fd_plain = os.open(path, os.O_RDONLY)
             fd_direct = None
@@ -419,6 +487,14 @@ def parallel_read_into_storage(
                     i += 1
                     ev.synchronize()  # buffer's previous H2D must be done
                     _read_chunk(fd_direct, fd_plain, view, f_off, ln)
+                    if can_ramp:
+                        with progress_lock:
+                            completed_reads += 1
+                            if completed_reads == decision_reads:
+                                should_ramp = (
+                                    time.perf_counter() - read_started >= ramp_threshold
+                                )
+                                ramp_decision.set()
                     with torch.cuda.stream(stream):
                         byte_views[blk].narrow(0, b_off, ln).copy_(
                             buf.narrow(0, 0, ln), non_blocking=True
@@ -434,12 +510,43 @@ def parallel_read_into_storage(
 
     threads = [
         threading.Thread(target=_reader, args=(i,), daemon=True)
-        for i in range(n_threads)
+        for i in range(base_threads)
     ]
+    extra_threads: list[threading.Thread] = []
+
+    def _ramp_controller() -> None:
+        ramp_decision.wait()
+        if not should_ramp or errors:
+            return
+        try:
+            _grow_pinned_pool(pool, max_threads, chunk_bytes)
+        except (MemoryError, RuntimeError):
+            # Ramping is optional: retain the working base readers if the
+            # host cannot pin the additional staging memory.
+            return
+        for i in range(base_threads, max_threads):
+            thread = threading.Thread(target=_reader, args=(i,), daemon=True)
+            try:
+                thread.start()
+            except RuntimeError:
+                break
+            extra_threads.append(thread)
+
+    controller = (
+        threading.Thread(target=_ramp_controller, daemon=True) if can_ramp else None
+    )
+    if controller is not None:
+        controller.start()
     for t in threads:
         t.start()
     for t in threads:
         t.join()
+    if controller is not None:
+        # An early read failure can prevent the completion threshold.
+        ramp_decision.set()
+        controller.join()
+        for t in extra_threads:
+            t.join()
     torch.cuda.synchronize(device)
     if not _env_flag("FLASHPACK_CACHE_PINNED"):
         release_pinned_pool()

--- a/tests/test_parallel_read_integrity.py
+++ b/tests/test_parallel_read_integrity.py
@@ -17,6 +17,7 @@ CUDA pipeline against the legacy reader on GPU hosts (marked ``gpu``).
 """
 
 import os
+import time
 from contextlib import contextmanager
 
 import numpy as np
@@ -94,6 +95,34 @@ def cpu_parallel_read(monkeypatch):
     monkeypatch.setenv("FLASHPACK_READ_THREADS", "4")
     monkeypatch.setenv("FLASHPACK_READ_CHUNK_BYTES", "8192")
     return monkeypatch
+
+
+@pytest.fixture()
+def fake_cuda_parallel_read(monkeypatch):
+    """Exercise CUDA reader orchestration with CPU destination tensors."""
+    growth: list[int] = []
+
+    def fake_pool(n_threads: int, chunk_bytes: int) -> list:
+        return [[torch.empty(chunk_bytes, dtype=torch.uint8)] for _ in range(n_threads)]
+
+    def fake_grow(pool: list, n_threads: int, chunk_bytes: int) -> None:
+        growth.append(n_threads)
+        pool.extend(
+            [torch.empty(chunk_bytes, dtype=torch.uint8)]
+            for _ in range(n_threads - len(pool))
+        )
+
+    monkeypatch.setattr(parallel_read.torch, "cuda", _FakeCuda)
+    monkeypatch.setattr(parallel_read, "_get_pinned_pool", fake_pool)
+    monkeypatch.setattr(parallel_read, "_grow_pinned_pool", fake_grow)
+    monkeypatch.setenv("FLASHPACK_READ_THREADS", "16")
+    monkeypatch.setenv("FLASHPACK_RAMP_THREADS", "32")
+    monkeypatch.setenv("FLASHPACK_READ_CHUNK_BYTES", "4096")
+    monkeypatch.setenv("FLASHPACK_DIRECT_IO", "1")
+    monkeypatch.setenv("FLASHPACK_CONDITIONAL_RAMP", "1")
+    monkeypatch.setattr(parallel_read.os, "O_DIRECT", 0, raising=False)
+    monkeypatch.setattr(parallel_read, "_page_cache_resident_fraction", lambda *_: 0.0)
+    return monkeypatch, growth
 
 
 def _make_file(
@@ -318,6 +347,97 @@ class TestErrorsNeverSilent:
         finally:
             os.close(fd_plain)
             os.close(fd_direct)
+
+
+@posix_only
+class TestConditionalRamp:
+    def test_slow_real_reads_ramp_without_probe_io(
+        self, tmp_path, fake_cuda_parallel_read
+    ) -> None:
+        monkeypatch, growth = fake_cuda_parallel_read
+        monkeypatch.setenv("FLASHPACK_RAMP_THRESHOLD_S", "0.001")
+        real_read_chunk = parallel_read._read_chunk
+        read_calls = 0
+
+        def slow_read_chunk(*args, **kwargs):
+            nonlocal read_calls
+            real_read_chunk(*args, **kwargs)
+            read_calls += 1
+            time.sleep(0.005)
+
+        monkeypatch.setattr(parallel_read, "_read_chunk", slow_read_chunk)
+        specs = [_uint8_spec(0, 64 * 4096)]
+        path, data = _make_file(tmp_path, specs)
+        blocks = [torch.zeros(specs[0].length_bytes, dtype=torch.uint8)]
+
+        parallel_read_into_storage(path, specs, blocks, torch.device("cuda"))
+
+        assert bytes(blocks[0].numpy()) == data
+        assert growth == [32]
+        assert read_calls == len(_plan_chunks(specs, 4096))
+
+    def test_fast_real_reads_do_not_allocate_extra_buffers(
+        self, tmp_path, fake_cuda_parallel_read
+    ) -> None:
+        monkeypatch, growth = fake_cuda_parallel_read
+        monkeypatch.setenv("FLASHPACK_RAMP_THRESHOLD_S", "60")
+        specs = [_uint8_spec(0, 64 * 4096)]
+        path, data = _make_file(tmp_path, specs)
+        blocks = [torch.zeros(specs[0].length_bytes, dtype=torch.uint8)]
+
+        parallel_read_into_storage(path, specs, blocks, torch.device("cuda"))
+
+        assert bytes(blocks[0].numpy()) == data
+        assert growth == []
+
+    def test_page_cache_hot_load_bypasses_ramp(
+        self, tmp_path, fake_cuda_parallel_read
+    ) -> None:
+        monkeypatch, growth = fake_cuda_parallel_read
+        monkeypatch.setenv("FLASHPACK_RAMP_THRESHOLD_S", "0")
+        monkeypatch.setattr(
+            parallel_read, "_page_cache_resident_fraction", lambda *_: 1.0
+        )
+        specs = [_uint8_spec(0, 64 * 4096)]
+        path, data = _make_file(tmp_path, specs)
+        blocks = [torch.zeros(specs[0].length_bytes, dtype=torch.uint8)]
+
+        parallel_read_into_storage(path, specs, blocks, torch.device("cuda"))
+
+        assert bytes(blocks[0].numpy()) == data
+        assert growth == []
+
+    def test_small_load_never_allocates_ramp_pool(
+        self, tmp_path, fake_cuda_parallel_read
+    ) -> None:
+        monkeypatch, growth = fake_cuda_parallel_read
+        monkeypatch.setenv("FLASHPACK_RAMP_THRESHOLD_S", "0")
+        specs = [_uint8_spec(0, 32 * 4096)]
+        path, data = _make_file(tmp_path, specs)
+        blocks = [torch.zeros(specs[0].length_bytes, dtype=torch.uint8)]
+
+        parallel_read_into_storage(path, specs, blocks, torch.device("cuda"))
+
+        assert bytes(blocks[0].numpy()) == data
+        assert growth == []
+
+    def test_ramp_allocation_failure_falls_back_to_base_readers(
+        self, tmp_path, fake_cuda_parallel_read
+    ) -> None:
+        monkeypatch, _ = fake_cuda_parallel_read
+        monkeypatch.setenv("FLASHPACK_RAMP_THRESHOLD_S", "0")
+
+        def fail_grow(*args, **kwargs):
+            raise RuntimeError("simulated pinned-memory pressure")
+
+        monkeypatch.setattr(parallel_read, "_grow_pinned_pool", fail_grow)
+        specs = [_uint8_spec(0, 64 * 4096)]
+        path, data = _make_file(tmp_path, specs)
+        blocks = [torch.zeros(specs[0].length_bytes, dtype=torch.uint8)]
+
+        parallel_read_into_storage(path, specs, blocks, torch.device("cuda"))
+
+        assert bytes(blocks[0].numpy()) == data
 
 
 class TestPlanChunksFuzz:


### PR DESCRIPTION
## Summary

- halve the initial CUDA pinned staging pool from 2 GiB to 1 GiB by using one buffer per reader
- conditionally grow slow, large direct reads from 16 to 32 readers after four real read completions, without probe I/O
- bypass the ramp for page-cache-hot and sub-4-GiB payloads, and fall back cleanly if additional pinned allocation fails
- expose environment overrides for disabling or tuning the ramp and cover the new policy with integrity tests

## JuiceFS benchmarks

All distributed results used eight H100s and verified the complete reconstructed payload byte-for-byte on every rank.

| Loading strategy | Baseline | Adaptive ramp | Time reduction |
|---|---:|---:|---:|
| rank-0 read + broadcast, 12 GiB | 20.20 s | 13.23 s | 34.5% |
| 1/rank windows + all-gather, 32 GiB | 22.98 s | 15.66 s | 31.8% |
| 1/rank contiguous + owner broadcasts, 32 GiB | 10.93 s | 7.84 s | 28.3% |

The measured H100 NCCL roof was 331 GiB/s for broadcast and 371 GiB/s for all-gather. Collective phases took only 35-133 ms, while end-to-end loading remained 0.6-4.1 GiB/s, confirming that these runs were JuiceFS-bound rather than fabric-bound.

Single-GPU cold-load measurements improved by 25.5% on the same node and 27.1% on a fresh node. Warm page-cache loads retained the 16-reader pool and did not ramp.

Eight-GPU B200 validation was attempted through four current app pools, but every request exhausted the platform allocation window without receiving hardware. No B200 result is claimed here.

## Test plan

- [x] configured prek hooks on both changed files
- [x] targeted reader integrity suite: 90 passed, 1 skipped
- [x] broader prepared-environment suite: 223 passed, 4 skipped
- [x] 8x H100 rank-0 broadcast correctness and timing
- [x] 8x H100 1/rank all-gather correctness and timing
- [x] 8x H100 1/rank owner-broadcast correctness and timing
